### PR TITLE
Simplifications

### DIFF
--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/RegisterAllocationConfig.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/RegisterAllocationConfig.java
@@ -32,6 +32,7 @@ import jdk.vm.ci.code.RegisterConfig;
 import jdk.vm.ci.meta.PlatformKind;
 
 import com.oracle.graal.compiler.common.GraalOptions;
+import com.oracle.graal.compiler.common.alloc.RegisterAllocationConfig.AllocatableRegisters;
 
 /**
  * Configuration for register allocation. This is different to {@link RegisterConfig} as it only
@@ -118,7 +119,20 @@ public class RegisterAllocationConfig {
     }
 
     protected AllocatableRegisters createAllocatableRegisters(Register[] registers) {
-        return new AllocatableRegisters(registers, registers[0].number, registers[registers.length - 1].number);
+        int min = Integer.MAX_VALUE;
+        int max = Integer.MIN_VALUE;
+        for (Register reg : registers) {
+            int number = reg.number;
+            if (number < min) {
+                min = number;
+            }
+            if (number > max) {
+                max = number;
+            }
+        }
+        assert min < max;
+        return new AllocatableRegisters(registers, min, max);
+
     }
 
     /**

--- a/graal/com.oracle.graal.hotspot.aarch64/src/com/oracle/graal/hotspot/aarch64/AArch64HotSpotRegisterAllocationConfig.java
+++ b/graal/com.oracle.graal.hotspot.aarch64/src/com/oracle/graal/hotspot/aarch64/AArch64HotSpotRegisterAllocationConfig.java
@@ -128,21 +128,4 @@ public class AArch64HotSpotRegisterAllocationConfig extends RegisterAllocationCo
 
         return super.initAllocatable(allocatableRegisters.toArray(new Register[allocatableRegisters.size()]));
     }
-
-    @Override
-    protected AllocatableRegisters createAllocatableRegisters(Register[] registers) {
-        int min = Integer.MAX_VALUE;
-        int max = Integer.MIN_VALUE;
-        for (Register reg : registers) {
-            int number = reg.number;
-            if (number < min) {
-                min = number;
-            }
-            if (number > max) {
-                max = number;
-            }
-        }
-        assert min < max;
-        return new AllocatableRegisters(registers, min, max);
-    }
 }

--- a/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotRegisterAllocationConfig.java
+++ b/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotRegisterAllocationConfig.java
@@ -100,21 +100,4 @@ class AMD64HotSpotRegisterAllocationConfig extends RegisterAllocationConfig {
 
         return super.initAllocatable(allocatableRegisters.toArray(new Register[allocatableRegisters.size()]));
     }
-
-    @Override
-    protected AllocatableRegisters createAllocatableRegisters(Register[] registers) {
-        int min = Integer.MAX_VALUE;
-        int max = Integer.MIN_VALUE;
-        for (Register reg : registers) {
-            int number = reg.number;
-            if (number < min) {
-                min = number;
-            }
-            if (number > max) {
-                max = number;
-            }
-        }
-        assert min < max;
-        return new AllocatableRegisters(registers, min, max);
-    }
 }

--- a/graal/com.oracle.graal.hotspot.sparc/src/com/oracle/graal/hotspot/sparc/SPARCHotSpotRegisterAllocationConfig.java
+++ b/graal/com.oracle.graal.hotspot.sparc/src/com/oracle/graal/hotspot/sparc/SPARCHotSpotRegisterAllocationConfig.java
@@ -131,21 +131,4 @@ public class SPARCHotSpotRegisterAllocationConfig extends RegisterAllocationConf
 
         return super.initAllocatable(allocatableRegisters.toArray(new Register[allocatableRegisters.size()]));
     }
-
-    @Override
-    protected AllocatableRegisters createAllocatableRegisters(Register[] registers) {
-        int min = Integer.MAX_VALUE;
-        int max = Integer.MIN_VALUE;
-        for (Register reg : registers) {
-            int number = reg.number;
-            if (number < min) {
-                min = number;
-            }
-            if (number > max) {
-                max = number;
-            }
-        }
-        assert min < max;
-        return new AllocatableRegisters(registers, min, max);
-    }
 }

--- a/graal/com.oracle.graal.lir.aarch64/src/com/oracle/graal/lir/aarch64/AArch64FrameMap.java
+++ b/graal/com.oracle.graal.lir.aarch64/src/com/oracle/graal/lir/aarch64/AArch64FrameMap.java
@@ -22,14 +22,13 @@
  */
 package com.oracle.graal.lir.aarch64;
 
+import com.oracle.graal.lir.framemap.FrameMap;
+
 import jdk.vm.ci.aarch64.AArch64Kind;
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.RegisterConfig;
 import jdk.vm.ci.code.StackSlot;
 import jdk.vm.ci.meta.LIRKind;
-
-import com.oracle.graal.asm.NumUtil;
-import com.oracle.graal.lir.framemap.FrameMap;
 
 /**
  * AArch64 specific frame map.
@@ -97,16 +96,6 @@ public class AArch64FrameMap extends FrameMap {
     @Override
     public int currentFrameSize() {
         return alignFrameSize(spillSize + outgoingSize - frameSetupSize());
-    }
-
-    @Override
-    protected int alignFrameSize(int size) {
-        return NumUtil.roundUp(size, getTarget().stackAlignment);
-    }
-
-    @Override
-    protected StackSlot allocateNewSpillSlot(LIRKind kind, int additionalOffset) {
-        return StackSlot.get(kind, -spillSize + additionalOffset, true);
     }
 
     public StackSlot allocateDeoptimizationRescueSlot() {

--- a/graal/com.oracle.graal.lir.amd64/src/com/oracle/graal/lir/amd64/AMD64FrameMap.java
+++ b/graal/com.oracle.graal.lir.amd64/src/com/oracle/graal/lir/amd64/AMD64FrameMap.java
@@ -39,7 +39,7 @@ import com.oracle.graal.lir.framemap.FrameMap;
  *
  * <pre>
  *   Base       Contents
- * 
+ *
  *            :                                :  -----
  *   caller   | incoming overflow argument n   |    ^
  *   frame    :     ...                        :    | positive
@@ -97,11 +97,6 @@ public class AMD64FrameMap extends FrameMap {
     @Override
     protected int alignFrameSize(int size) {
         return NumUtil.roundUp(size + returnAddressSize(), getTarget().stackAlignment) - returnAddressSize();
-    }
-
-    @Override
-    protected StackSlot allocateNewSpillSlot(LIRKind kind, int additionalOffset) {
-        return StackSlot.get(kind, -spillSize + additionalOffset, true);
     }
 
     @Override

--- a/graal/com.oracle.graal.lir.sparc/src/com/oracle/graal/lir/sparc/SPARCFrameMap.java
+++ b/graal/com.oracle.graal.lir.sparc/src/com/oracle/graal/lir/sparc/SPARCFrameMap.java
@@ -22,15 +22,14 @@
  */
 package com.oracle.graal.lir.sparc;
 
+import com.oracle.graal.lir.framemap.FrameMap;
+
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.RegisterConfig;
 import jdk.vm.ci.code.StackSlot;
 import jdk.vm.ci.meta.LIRKind;
 import jdk.vm.ci.sparc.SPARC;
 import jdk.vm.ci.sparc.SPARCKind;
-
-import com.oracle.graal.asm.NumUtil;
-import com.oracle.graal.lir.framemap.FrameMap;
 
 /**
  * SPARC specific frame map.
@@ -93,16 +92,6 @@ public final class SPARCFrameMap extends FrameMap {
     @Override
     public int currentFrameSize() {
         return alignFrameSize(SPARC.REGISTER_SAFE_AREA_SIZE + outgoingSize + spillSize);
-    }
-
-    @Override
-    protected int alignFrameSize(int size) {
-        return NumUtil.roundUp(size, getTarget().stackAlignment);
-    }
-
-    @Override
-    protected StackSlot allocateNewSpillSlot(LIRKind kind, int additionalOffset) {
-        return StackSlot.get(kind, -spillSize + additionalOffset, true);
     }
 
     /**

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/framemap/FrameMap.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/framemap/FrameMap.java
@@ -181,7 +181,9 @@ public abstract class FrameMap {
      * @param size the initial frame size to be aligned
      * @return the aligned frame size
      */
-    protected abstract int alignFrameSize(int size);
+    protected int alignFrameSize(int size) {
+        return NumUtil.roundUp(size, getTarget().stackAlignment);
+    }
 
     /**
      * Computes the final size of this frame. After this method has been called, methods that change
@@ -238,7 +240,9 @@ public abstract class FrameMap {
      * @param additionalOffset
      * @return A spill slot denoting the reserved memory area.
      */
-    protected abstract StackSlot allocateNewSpillSlot(LIRKind kind, int additionalOffset);
+    protected StackSlot allocateNewSpillSlot(LIRKind kind, int additionalOffset) {
+        return StackSlot.get(kind, -spillSize + additionalOffset, true);
+    }
 
     /**
      * Returns the spill slot size for the given {@link LIRKind}. The default value is the size in


### PR DESCRIPTION
- All the subclasses of `RegisterAllocationConfig` were overriding `createAllocatableRegisters` with a standard implementation that does not make assumptions about the order of the elements in the registers parameter. Using this generic implementation in `RegisterAllocationConfig` allows to remove all the overrides.
- Create default implementations for `alignFrameSize` and `allocateNewSpillSlot`. This implifies creating `FrameMap` subclasses by implementing common behaviour.