### PR TITLE
Resurrect old mx gate and add --simple flag for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
   - export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
 script:
-  - mx --strict-compliance gate --strict-mode
+  - mx --strict-compliance gate --strict-mode --simple
 after_failure:
   - cat $TRAVIS_BUILD_DIR/jvmci/client-product.log
   - cat $TRAVIS_BUILD_DIR/jvmci/server-fastdebug.log

--- a/mx.graal-core/mx_graal_8.py
+++ b/mx.graal-core/mx_graal_8.py
@@ -313,8 +313,8 @@ graal_bootstrap_tests = [
     BootstrapTest('BootstrapWithG1GCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:-UseSerialGC', '-XX:+UseG1GC', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),
     BootstrapTest('BootstrapEconomyWithSystemAssertions', 'fastdebug', ['-esa', '-Djvmci.compiler=graal-economy', '-G:+ExitVMOnException']),
     BootstrapTest('BootstrapWithExceptionEdges', 'fastdebug', ['-esa', '-G:+StressInvokeWithExceptionNode', '-G:+ExitVMOnException']),
-    BootstrapTest('BootstrapWithRegisterPressure', 'product', ['-esa', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException']),
-    BootstrapTest('BootstrapTraceRAWithRegisterPressure', 'product', ['-esa', '-G:+TraceRA', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapWithRegisterPressure', 'product', ['-esa', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException', '-G:+LIRUnlockBackendRestart']),
+    BootstrapTest('BootstrapTraceRAWithRegisterPressure', 'product', ['-esa', '-G:+TraceRA', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException', '-G:+LIRUnlockBackendRestart']),
     BootstrapTest('BootstrapWithImmutableCode', 'product', ['-esa', '-G:+ImmutableCode', '-G:+VerifyPhases', '-G:+ExitVMOnException']),
  ]
 

--- a/mx.graal-core/mx_graal_8.py
+++ b/mx.graal-core/mx_graal_8.py
@@ -27,6 +27,7 @@
 import os
 from os.path import join, exists, basename
 from argparse import ArgumentParser
+import sanitycheck
 import re
 
 import mx
@@ -37,6 +38,7 @@ from mx_gate import Task
 from sanitycheck import _noneAsEmptyList
 
 from mx_unittest import unittest
+from mx_graal_bench import dacapo
 import mx_gate
 import mx_unittest
 
@@ -217,22 +219,24 @@ class UnitTestRun:
     def run(self, suites, tasks, extraVMarguments=None):
         for suite in suites:
             with Task(self.name + ': hosted-product ' + suite, tasks) as t:
-                if t: unittest(['--suite', suite, '--fail-fast'] + self.args + _noneAsEmptyList(extraVMarguments))
+                if t: unittest(['--suite', suite, '--enable-timing', '--verbose', '--fail-fast'] + self.args + _noneAsEmptyList(extraVMarguments))
 
 class BootstrapTest:
-    def __init__(self, name, args, suppress=None):
+    def __init__(self, name, vmbuild, args, suppress=None):
         self.name = name
+        self.vmbuild = vmbuild
         self.args = args
         self.suppress = suppress
 
     def run(self, tasks, extraVMarguments=None):
-        with Task(self.name + ':fastdebug', tasks) as t:
-            if t:
-                if self.suppress:
-                    out = mx.DuplicateSuppressingStream(self.suppress).write
-                else:
-                    out = None
-                run_vm(self.args + _noneAsEmptyList(extraVMarguments) + ['-esa', '-G:+ExitVMOnException', '-XX:-TieredCompilation', '-XX:+BootstrapJVMCI', '-version'], out=out)
+        with VM('jvmci', self.vmbuild):
+            with Task(self.name + ':' + self.vmbuild, tasks) as t:
+                if t:
+                    if self.suppress:
+                        out = mx.DuplicateSuppressingStream(self.suppress).write
+                    else:
+                        out = None
+                    run_vm(self.args + _noneAsEmptyList(extraVMarguments) + ['-XX:-TieredCompilation', '-XX:+BootstrapJVMCI', '-version'], out=out)
 
 class MicrobenchRun:
     def __init__(self, name, args):
@@ -244,31 +248,75 @@ class MicrobenchRun:
             if t: microbench(_noneAsEmptyList(extraVMarguments) + ['--'] + self.args)
 
 def compiler_gate_runner(suites, unit_test_runs, bootstrap_tests, tasks, extraVMarguments=None):
-    # Run unit tests on server-hosted-jvmci
-    with VM('jvmci', 'fastdebug'):
-        # Build
-        with Task('BuildHotSpotJVMCI: fastdebug', tasks) as t:
-            if t: buildvms(['--vms', 'jvmci', '--builds', 'fastdebug'])
 
+    # Build server-hosted-jvmci now so we can run the unit tests
+    with Task('BuildHotSpotGraalHosted: product', tasks) as t:
+        if t: buildvms(['--vms', 'server', '--builds', 'product'])
+
+    with VM('server', 'product'):
+    # Run unit tests on server-hosted-jvmci
         for r in unit_test_runs:
             r.run(suites, tasks, extraVMarguments)
 
-        # Run microbench (only for testing the JMH setup)
+    # Run microbench on server-hosted-jvmci (only for testing the JMH setup)
+    with VM('server', 'product'):
         for r in [MicrobenchRun('Microbench', ['TestJMH'])]:
             r.run(tasks, extraVMarguments)
 
-        # bootstrap tests
-        for b in bootstrap_tests:
-            b.run(tasks, extraVMarguments)
+    # Run ctw against rt.jar on server-hosted-jvmci
+    with VM('server', 'product'):
+        with Task('CTW:hosted-product', tasks) as t:
+            if t: ctw(['--ctwopts', '-Inline +ExitVMOnException', '-esa', '-G:+CompileTheWorldMultiThreaded', '-G:-InlineDuringParsing', '-G:-CompileTheWorldVerbose', '-XX:ReservedCodeCacheSize=400m'], _noneAsEmptyList(extraVMarguments))
+
+    # Build the jvmci VMs so we can run the other tests
+    with Task('BuildHotSpotGraalOthers: fastdebug,product', tasks) as t:
+        if t: buildvms(['--vms', 'jvmci', '--builds', 'fastdebug,product'])
+
+    # bootstrap tests
+    for b in bootstrap_tests:
+        b.run(tasks, extraVMarguments)
+
+    # run dacapo sanitychecks
+    for vmbuild in ['fastdebug', 'product']:
+        for test in sanitycheck.getDacapos(level=sanitycheck.SanityCheckLevel.Gate, gateBuildLevel=vmbuild, extraVmArguments=extraVMarguments) \
+                + sanitycheck.getScalaDacapos(level=sanitycheck.SanityCheckLevel.Gate, gateBuildLevel=vmbuild, extraVmArguments=extraVMarguments):
+            with Task(str(test) + ':' + vmbuild, tasks) as t:
+                if t and not test.test('jvmci'):
+                    t.abort(test.name + ' Failed')
+
+    # ensure -Xbatch still works
+    with VM('jvmci', 'product'):
+        with Task('DaCapo_pmd:BatchMode:product', tasks) as t:
+            if t: dacapo(_noneAsEmptyList(extraVMarguments) + ['-Xbatch', 'pmd'])
+
+    # ensure benchmark counters still work
+    with VM('jvmci', 'product'):
+        with Task('DaCapo_pmd:BenchmarkCounters:product', tasks) as t:
+            if t: dacapo(_noneAsEmptyList(extraVMarguments) + ['-G:+LIRProfileMoves', '-G:+GenericDynamicCounters', '-XX:JVMCICounterSize=10', 'pmd'])
+
+    # ensure -Xcomp still works
+    with VM('jvmci', 'product'):
+        with Task('XCompMode:product', tasks) as t:
+            if t: run_vm(_noneAsEmptyList(extraVMarguments) + ['-Xcomp', '-version'])
 
 
 graal_unit_test_runs = [
     UnitTestRun('UnitTests', []),
 ]
 
+_registers = 'o0,o1,o2,o3,f8,f9,d32,d34' if mx.get_arch() == 'sparcv9' else 'rbx,r11,r10,r14,xmm3,xmm11,xmm14'
+
 graal_bootstrap_tests = [
-    BootstrapTest('BootstrapWithSystemAssertions', []),
-]
+    BootstrapTest('BootstrapWithSystemAssertions', 'fastdebug', ['-esa']),
+    BootstrapTest('BootstrapWithSystemAssertionsNoCoop', 'fastdebug', ['-esa', '-XX:-UseCompressedOops', '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapWithGCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),
+    BootstrapTest('BootstrapWithG1GCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:-UseSerialGC', '-XX:+UseG1GC', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),
+    BootstrapTest('BootstrapEconomyWithSystemAssertions', 'fastdebug', ['-esa', '-Djvmci.compiler=graal-economy', '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapWithExceptionEdges', 'fastdebug', ['-esa', '-G:+StressInvokeWithExceptionNode', '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapWithRegisterPressure', 'product', ['-esa', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapTraceRAWithRegisterPressure', 'product', ['-esa', '-G:+TraceRA', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapWithImmutableCode', 'product', ['-esa', '-G:+ImmutableCode', '-G:+VerifyPhases', '-G:+ExitVMOnException']),
+ ]
 
 def _graal_gate_runner(args, tasks):
     compiler_gate_runner(['graal-core', 'truffle'], graal_unit_test_runs, graal_bootstrap_tests, tasks, args.extra_vm_argument)

--- a/mx.graal-core/mx_graal_8.py
+++ b/mx.graal-core/mx_graal_8.py
@@ -219,7 +219,7 @@ class UnitTestRun:
     def run(self, suites, tasks, extraVMarguments=None):
         for suite in suites:
             with Task(self.name + ': hosted-product ' + suite, tasks) as t:
-                if t: unittest(['--suite', suite, '--enable-timing', '--verbose', '--fail-fast'] + self.args + _noneAsEmptyList(extraVMarguments))
+                if t: unittest(['--suite', suite, '--fail-fast'] + self.args + _noneAsEmptyList(extraVMarguments))
 
 class BootstrapTest:
     def __init__(self, name, vmbuild, args, suppress=None):

--- a/mx.graal-core/mx_graal_9.py
+++ b/mx.graal-core/mx_graal_9.py
@@ -204,7 +204,7 @@ class UnitTestRun:
     def run(self, suites, tasks, extraVMarguments=None):
         for suite in suites:
             with Task(self.name + ': hosted-product ' + suite, tasks) as t:
-                if t: unittest(['--suite', suite, '--enable-timing', '--verbose', '--fail-fast'] + self.args + _noneAsEmptyList(extraVMarguments))
+                if t: unittest(['--suite', suite, '--fail-fast'] + self.args + _noneAsEmptyList(extraVMarguments))
 
 class BootstrapTest:
     def __init__(self, name, vmbuild, args, suppress=None):

--- a/mx.graal-core/mx_graal_9.py
+++ b/mx.graal-core/mx_graal_9.py
@@ -288,8 +288,8 @@ graal_bootstrap_tests = [
     BootstrapTest('BootstrapWithG1GCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:-UseSerialGC', '-XX:+UseG1GC', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),
     BootstrapTest('BootstrapEconomyWithSystemAssertions', 'fastdebug', ['-esa', '-Djvmci.compiler=graal-economy', '-G:+ExitVMOnException']),
     BootstrapTest('BootstrapWithExceptionEdges', 'fastdebug', ['-esa', '-G:+StressInvokeWithExceptionNode', '-G:+ExitVMOnException']),
-    BootstrapTest('BootstrapWithRegisterPressure', 'product', ['-esa', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException']),
-    BootstrapTest('BootstrapTraceRAWithRegisterPressure', 'product', ['-esa', '-G:+TraceRA', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException']),
+    BootstrapTest('BootstrapWithRegisterPressure', 'product', ['-esa', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException', '-G:+LIRUnlockBackendRestart']),
+    BootstrapTest('BootstrapTraceRAWithRegisterPressure', 'product', ['-esa', '-G:+TraceRA', '-G:RegisterPressure=' + _registers, '-G:+ExitVMOnException', '-G:+LIRUnlockBackendRestart']),
     BootstrapTest('BootstrapWithImmutableCode', 'product', ['-esa', '-G:+ImmutableCode', '-G:+VerifyPhases', '-G:+ExitVMOnException']),
 ]
 


### PR DESCRIPTION
Pull request #3 changed the behavior of `mx gate` in a non-trivial way to make it run on travis. This PR reverts that change and restores the functionality of running a full gate. It also adds the `--simple` flag to `mx gate` which is equivalent to the reduced gate currently executed by travis.