### PR TITLE
CompiledExceptionHandlerTest should not rely on profiling information.

### DIFF
--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/GraalOptions.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/GraalOptions.java
@@ -122,11 +122,11 @@ public final class GraalOptions {
     @Option(help = "", type = OptionType.Debug)
     public static final OptionValue<Boolean> DeoptALot = new OptionValue<>(false);
 
-    @Option(help = "Stressed the code emitting explicit exception throwing code.", type = OptionType.Debug)
-    public static final StableOptionValue<Boolean> StressExplicitExceptionCode = new StableOptionValue<>(false);
+    @Option(help = "Stress the code emitting explicit exception throwing code.", type = OptionType.Debug)
+    public static final OptionValue<Boolean> StressExplicitExceptionCode = new OptionValue<>(false);
 
-    @Option(help = "Stressed the code emitting explicit exception throwing code.", type = OptionType.Debug)
-    public static final StableOptionValue<Boolean> StressInvokeWithExceptionNode = new StableOptionValue<>(false);
+    @Option(help = "Stress the code emitting invokes with explicit exception edges.", type = OptionType.Debug)
+    public static final OptionValue<Boolean> StressInvokeWithExceptionNode = new OptionValue<>(false);
 
     @Option(help = "", type = OptionType.Debug)
     public static final OptionValue<Boolean> VerifyPhases = new OptionValue<>(false);

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -1399,10 +1399,15 @@ public class BytecodeParser implements GraphBuilderContext {
      * @param callTarget The call target.
      */
     protected boolean omitInvokeExceptionEdge(MethodCallTargetNode callTarget) {
-        // be conservative if information was not recorded (could result in endless
-        // recompiles otherwise)
-        return lastInlineInfo == InlineInfo.DO_NOT_INLINE_NO_EXCEPTION || graphBuilderConfig.omitAllExceptionEdges() ||
-                        (!StressInvokeWithExceptionNode.getValue() && optimisticOpts.useExceptionProbability() && profilingInfo != null && profilingInfo.getExceptionSeen(bci()) == TriState.FALSE);
+        if (lastInlineInfo == InlineInfo.DO_NOT_INLINE_WITH_EXCEPTION) {
+            return false;
+        } else if (lastInlineInfo == InlineInfo.DO_NOT_INLINE_NO_EXCEPTION || graphBuilderConfig.omitAllExceptionEdges()) {
+            return true;
+        } else {
+            // be conservative if information was not recorded (could result in endless
+            // recompiles otherwise)
+            return (!StressInvokeWithExceptionNode.getValue() && optimisticOpts.useExceptionProbability() && profilingInfo != null && profilingInfo.getExceptionSeen(bci()) == TriState.FALSE);
+        }
     }
 
     /**


### PR DESCRIPTION
This unit test sometimes randomly failed on travis, now it should be reliable.