### PR TITLE
Add missing checkstyle declaration.

### DIFF
--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -130,6 +130,7 @@ suite = {
       "subDir" : "graal",
       "sourceDirs" : ["src"],
       "dependencies" : deps(["jvmci:JVMCI_SERVICES"]),
+      "checkstyle" : "com.oracle.graal.graph",
       "javaCompliance" : "1.8",
       "workingSets" : "API,Graal",
     },


### PR DESCRIPTION
Fixes this problem in the gate:
```
gate: 15 Feb 2016 10:46:08: BEGIN: Checkheaders
Cannot check headers for com.oracle.graal.serviceprovider - /home/travis/build/graalvm/graal-core/graal/com.oracle.graal.serviceprovider/.checkstyle_checks.xml does not exist
gate: 15 Feb 2016 10:46:08: END:   Checkheaders [0:00:00.272014] [disk (free/total): 15.7GB/29.5GB]
```