### PR TITLE
[SPARC] Fix saved registers for Stub calls

### DIFF
--- a/graal/com.oracle.graal.compiler/src/com/oracle/graal/compiler/target/Backend.java
+++ b/graal/com.oracle.graal.compiler/src/com/oracle/graal/compiler/target/Backend.java
@@ -22,8 +22,11 @@
  */
 package com.oracle.graal.compiler.target;
 
+import java.util.Set;
+
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.CompiledCode;
+import jdk.vm.ci.code.Register;
 import jdk.vm.ci.code.RegisterConfig;
 import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.meta.ConstantReflectionProvider;
@@ -133,5 +136,12 @@ public abstract class Backend implements TargetProvider {
      *            installed. This argument can be null.
      */
     public abstract void emitCode(CompilationResultBuilder crb, LIR lir, ResolvedJavaMethod installedCodeOwner);
+
+    /**
+     * Translates a set of registers from the callee's perspective to the caller's perspective. This
+     * is needed for architectures where input/output registers are renamed during a call (e.g.
+     * register windows on SPARC). Registers which are not visible by the caller are removed.
+     */
+    public abstract Set<Register> translateToCallerRegisters(Set<Register> calleeRegisters);
 
 }

--- a/graal/com.oracle.graal.hotspot.aarch64/src/com/oracle/graal/hotspot/aarch64/AArch64HotSpotBackend.java
+++ b/graal/com.oracle.graal.hotspot.aarch64/src/com/oracle/graal/hotspot/aarch64/AArch64HotSpotBackend.java
@@ -227,8 +227,8 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend {
         }
 
         if (stub != null) {
-            Set<Register> definedRegisters = gatherDefinedRegisters(lir);
-            updateStub(stub, definedRegisters, gen.getCalleeSaveInfo(), frameMap);
+            Set<Register> destroyedCallerRegisters = gatherDestroyedCallerRegisters(lir);
+            updateStub(stub, destroyedCallerRegisters, gen.getCalleeSaveInfo(), frameMap);
         }
         return crb;
     }
@@ -319,5 +319,10 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend {
     public RegisterAllocationConfig newRegisterAllocationConfig(RegisterConfig registerConfig) {
         RegisterConfig registerConfigNonNull = registerConfig == null ? getCodeCache().getRegisterConfig() : registerConfig;
         return new AArch64HotSpotRegisterAllocationConfig(registerConfigNonNull);
+    }
+
+    @Override
+    public Set<Register> translateToCallerRegisters(Set<Register> calleeRegisters) {
+        return calleeRegisters;
     }
 }

--- a/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotBackend.java
+++ b/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotBackend.java
@@ -216,8 +216,8 @@ public class AMD64HotSpotBackend extends HotSpotHostBackend {
         }
 
         if (stub != null) {
-            Set<Register> definedRegisters = gatherDefinedRegisters(lir);
-            updateStub(stub, definedRegisters, gen.getCalleeSaveInfo(), frameMap);
+            Set<Register> destroyedCallerRegisters = gatherDestroyedCallerRegisters(lir);
+            updateStub(stub, destroyedCallerRegisters, gen.getCalleeSaveInfo(), frameMap);
         }
 
         return crb;
@@ -316,5 +316,10 @@ public class AMD64HotSpotBackend extends HotSpotHostBackend {
     public RegisterAllocationConfig newRegisterAllocationConfig(RegisterConfig registerConfig) {
         RegisterConfig registerConfigNonNull = registerConfig == null ? getCodeCache().getRegisterConfig() : registerConfig;
         return new AMD64HotSpotRegisterAllocationConfig(registerConfigNonNull);
+    }
+
+    @Override
+    public Set<Register> translateToCallerRegisters(Set<Register> calleeRegisters) {
+        return calleeRegisters;
     }
 }

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/HotSpotBackend.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/HotSpotBackend.java
@@ -205,15 +205,15 @@ public abstract class HotSpotBackend extends Backend implements FrameMap.Referen
      * @param lir the LIR to examine
      * @return the registers that are defined by or used as temps for any instruction in {@code lir}
      */
-    protected static Set<Register> gatherDefinedRegisters(LIR lir) {
-        final Set<Register> definedRegisters = new HashSet<>();
+    protected final Set<Register> gatherDestroyedCallerRegisters(LIR lir) {
+        final Set<Register> destroyedRegisters = new HashSet<>();
         ValueConsumer defConsumer = new ValueConsumer() {
 
             @Override
             public void visitValue(Value value, OperandMode mode, EnumSet<OperandFlag> flags) {
                 if (ValueUtil.isRegister(value)) {
                     final Register reg = ValueUtil.asRegister(value);
-                    definedRegisters.add(reg);
+                    destroyedRegisters.add(reg);
                 }
             }
         };
@@ -227,7 +227,7 @@ public abstract class HotSpotBackend extends Backend implements FrameMap.Referen
                 }
             }
         }
-        return definedRegisters;
+        return translateToCallerRegisters(destroyedRegisters);
     }
 
     /**
@@ -247,7 +247,7 @@ public abstract class HotSpotBackend extends Backend implements FrameMap.Referen
      *            slot to a frame slot index
      */
     protected void updateStub(Stub stub, Set<Register> destroyedRegisters, Map<LIRFrameState, SaveRegistersOp> calleeSaveInfo, FrameMap frameMap) {
-        stub.initDestroyedRegisters(destroyedRegisters);
+        stub.initDestroyedCallerRegisters(destroyedRegisters);
 
         for (Map.Entry<LIRFrameState, SaveRegistersOp> e : calleeSaveInfo.entrySet()) {
             SaveRegistersOp save = e.getValue();

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/HotSpotForeignCallLinkageImpl.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/HotSpotForeignCallLinkageImpl.java
@@ -221,7 +221,7 @@ public class HotSpotForeignCallLinkageImpl extends HotSpotForeignCallTarget impl
             assert stub != null : "linkage without an address must be a stub - forgot to register a Stub associated with " + descriptor + "?";
             InstalledCode code = stub.getCode(backend);
 
-            Set<Register> destroyedRegisters = stub.getDestroyedRegisters();
+            Set<Register> destroyedRegisters = stub.getDestroyedCallerRegisters();
             if (!destroyedRegisters.isEmpty()) {
                 AllocatableValue[] temporaryLocations = new AllocatableValue[destroyedRegisters.size()];
                 int i = 0;

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/Stub.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/Stub.java
@@ -87,28 +87,28 @@ public abstract class Stub {
     protected CompilationResult compResult;
 
     /**
-     * The registers destroyed by this stub.
+     * The registers destroyed by this stub (from the caller's perspective).
      */
-    private Set<Register> destroyedRegisters;
+    private Set<Register> destroyedCallerRegisters;
 
-    public void initDestroyedRegisters(Set<Register> registers) {
+    public void initDestroyedCallerRegisters(Set<Register> registers) {
         assert registers != null;
-        assert destroyedRegisters == null || registers.equals(destroyedRegisters) : "cannot redefine";
-        destroyedRegisters = registers;
+        assert destroyedCallerRegisters == null || registers.equals(destroyedCallerRegisters) : "cannot redefine";
+        destroyedCallerRegisters = registers;
     }
 
     /**
-     * Gets the registers defined by this stub. These are the temporaries of this stub and must thus
-     * be caller saved by a callers of this stub.
+     * Gets the registers destroyed by this stub from a caller's perspective. These are the
+     * temporaries of this stub and must thus be caller saved by a callers of this stub.
      */
-    public Set<Register> getDestroyedRegisters() {
-        assert destroyedRegisters != null : "not yet initialized";
-        return destroyedRegisters;
+    public Set<Register> getDestroyedCallerRegisters() {
+        assert destroyedCallerRegisters != null : "not yet initialized";
+        return destroyedCallerRegisters;
     }
 
     /**
      * Determines if this stub preserves all registers apart from those it
-     * {@linkplain #getDestroyedRegisters() destroys}.
+     * {@linkplain #getDestroyedCallerRegisters() destroys}.
      */
     public boolean preservesRegisters() {
         return true;
@@ -189,7 +189,7 @@ public abstract class Stub {
                     throw Debug.handle(e);
                 }
 
-                assert destroyedRegisters != null;
+                assert destroyedCallerRegisters != null;
                 try (Scope s = Debug.scope("CodeInstall")) {
                     HotSpotCompiledCode compiledCode = HotSpotCompiledCodeBuilder.createCompiledCode(null, null, compResult);
                     code = codeCache.installCode(null, compiledCode, null, null, false);


### PR DESCRIPTION
`Stub.getDestroyedRegisters()` returns the destroyed registers from the Stubs (the callees) point of view. Architectures which perform register renaming need to translate this to the callers perspective as it is used to set the temporaries of the call op.

~~In the proposed solution the translation is done by the a newly introduced method `Backend.viewAsCaller()` during `HotSpotForeignCallLinkageImpl.finalizeAddress()`~~

Alternatively we could change the behavior of `Stub.getDestroyedRegisters()` to return the translated set in the first place. In this case we could omit the `Backend` change. Personally I think this solution is counter-intuitive as I would expect that the destroyed registers set is from the Stubs perspective. On the other hand the method is only used for this purpose so we could rename it to make its behavior clearer.
(**Update:** this is now the proposed solution)

Comments/suggestions very welcome.

RFR: @rschatz @tkrodriguez 