### PR TITLE
Add jdk9 to test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,23 +20,40 @@ dist: trusty
 env:
   global:
     - DEFAULT_VM="jvmci"
-before_install:
-  - virtualenv venv
-  - source venv/bin/activate
-  - pip install astroid==1.1.0
-  - pip install pylint==1.1.0
+    - MX_BINARY_SUITES="jvmci,truffle"
+  matrix:
+    - JDK="jdk8" GATE="build,style,test"
+    - JDK="jdk9" GATE="build,test"
 install:
-  - export MX_PATH=$TRAVIS_BUILD_DIR/../mx
-  - git clone https://github.com/graalvm/mx.git $MX_PATH
-  - export PATH=$MX_PATH/../mx:$PATH
-  - export JDT=$MX_PATH/ecj.jar
-  - wget http://ftp.halifax.rwth-aachen.de/eclipse//eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar -O $JDT
-  - export ECLIPSE_TAR=$TRAVIS_BUILD_DIR/../eclipse.tar.gz
-  - wget https://lafo.ssw.uni-linz.ac.at/slavefiles/gate/eclipse-jdk8-linux-x86_64.tar.gz -O $ECLIPSE_TAR
-  - tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
-  - export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
-  - export MX_BINARY_SUITES=jvmci,truffle
+  - |
+      export MX_PATH=$TRAVIS_BUILD_DIR/../mx
+      git clone https://github.com/graalvm/mx.git $MX_PATH
+      export PATH=$MX_PATH/../mx:$PATH
+  - |
+      if [[ $GATE == *style* ]]
+      then
+        virtualenv venv
+        source venv/bin/activate
+        pip install astroid==1.1.0
+        pip install pylint==1.1.0
+
+        export JDT=$MX_PATH/ecj.jar
+        wget http://ftp.halifax.rwth-aachen.de/eclipse//eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar -O $JDT
+
+        export ECLIPSE_TAR=$TRAVIS_BUILD_DIR/../eclipse.tar.gz
+        wget https://lafo.ssw.uni-linz.ac.at/slavefiles/gate/eclipse-jdk8-linux-x86_64.tar.gz -O $ECLIPSE_TAR
+        tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
+        export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
+      fi
+  - |
+      if [ "$JDK" == "jdk9" ]
+      then
+        JDK_TAR=$TRAVIS_BUILD_DIR/../jdk9-SNAPSHOT-fastdebug-linux-amd64.tar.gz
+        wget https://lafo.ssw.uni-linz.ac.at/slavefiles/jdk/jdk9-SNAPSHOT-fastdebug-linux-amd64.tar.gz -O $JDK_TAR
+        tar -C $TRAVIS_BUILD_DIR/.. -xf $JDK_TAR
+        export JAVA_HOME=$TRAVIS_BUILD_DIR/../jdk1.9.0
+      fi
 script:
-  - mx --strict-compliance gate --strict-mode --tags build,style,test
+  - mx --strict-compliance gate --strict-mode --tags $GATE
 after_failure:
   - cat hs_err*


### PR DESCRIPTION
This runs the gate on our jdk9 snapshot in parallel to the normal gate. The jdk9 gate skips the style checks (checkstyle, findbugs, ...), they would be redundant.