### PR TITLE
Use Parameterized JUnit runner for BC_{f,d}{div,rem}.

### DIFF
--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_ddiv.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_ddiv.java
@@ -32,9 +32,8 @@ public class BC_ddiv extends BC_ddiv_drem_base {
     }
 
     @Test
-    @Override
-    public void run() {
-        super.run();
+    public void ddiv() {
+        runTest("test", x, y);
     }
 
 }

--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_ddiv_drem_base.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_ddiv_drem_base.java
@@ -23,8 +23,18 @@
 
 package com.oracle.graal.jtt.bytecode;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
 import com.oracle.graal.jtt.JTTTest;
 
+@RunWith(Parameterized.class)
 public abstract class BC_ddiv_drem_base extends JTTTest {
 
     /** Some interesting values. */
@@ -42,14 +52,19 @@ public abstract class BC_ddiv_drem_base extends JTTTest {
                     -311.0d,
     };
 
-    public void run() {
+    @Parameters(name = "{0}, {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> d = new ArrayList<>();
         for (int i = 0; i < values.length; i++) {
             double x = values[i];
             for (int j = 0; j < values.length; j++) {
                 double y = values[j];
-                runTest("test", x, y);
+                d.add(new Object[]{x, y});
             }
         }
+        return d;
     }
 
+    @Parameter(value = 0) public double x;
+    @Parameter(value = 1) public double y;
 }

--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_drem.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_drem.java
@@ -32,9 +32,8 @@ public class BC_drem extends BC_ddiv_drem_base {
     }
 
     @Test
-    @Override
-    public void run() {
-        super.run();
+    public void drem() {
+        runTest("test", x, y);
     }
 
 }

--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_fdiv.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_fdiv.java
@@ -32,9 +32,8 @@ public class BC_fdiv extends BC_fdiv_frem_base {
     }
 
     @Test
-    @Override
-    public void run() {
-        super.run();
+    public void fdiv() {
+        runTest("test", x, y);
     }
 
 }

--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_fdiv_frem_base.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_fdiv_frem_base.java
@@ -23,8 +23,18 @@
 
 package com.oracle.graal.jtt.bytecode;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
 import com.oracle.graal.jtt.JTTTest;
 
+@RunWith(Parameterized.class)
 public abstract class BC_fdiv_frem_base extends JTTTest {
 
     /** Some interesting values. */
@@ -42,14 +52,20 @@ public abstract class BC_fdiv_frem_base extends JTTTest {
                     -311.0f,
     };
 
-    public void run() {
+    @Parameters(name = "{0}, {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> d = new ArrayList<>();
         for (int i = 0; i < values.length; i++) {
             float x = values[i];
             for (int j = 0; j < values.length; j++) {
                 float y = values[j];
-                runTest("test", x, y);
+                d.add(new Object[]{x, y});
             }
         }
+        return d;
     }
+
+    @Parameter(value = 0) public float x;
+    @Parameter(value = 1) public float y;
 
 }

--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_frem.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_frem.java
@@ -32,9 +32,8 @@ public class BC_frem extends BC_fdiv_frem_base {
     }
 
     @Test
-    @Override
-    public void run() {
-        super.run();
+    public void frem() {
+        runTest("test", x, y);
     }
 
 }


### PR DESCRIPTION
This is a minor update to #35 by @christhalinger. Instead of running all combinations in a single `@Test` method it uses the `@Parameters` feature of junit to run each combination individually. This  is especially useful if used with the `--verbose` flag:
```
$ smx unittest --verbose BC_drem
MxJUnitCore
JUnit version 4.11
com.oracle.graal.jtt.bytecode.BC_drem started
  drem[0: 0, 0]: Passed
  drem[1: 0, -0]: Passed
  drem[2: 0, 1]: Passed
  drem[3: 0, -1]: Passed
  drem[4: 0, ∞]: Passed
  drem[5: 0, -∞]: Passed
...
```