### PR TITLE
CTW exclude filters should only control compilation

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/CompileTheWorld.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/CompileTheWorld.java
@@ -556,13 +556,6 @@ public final class CompileTheWorld {
 
                     classFileCounter++;
 
-                    if (methodFilters != null && !MethodFilter.matchesClassName(methodFilters, className)) {
-                        continue;
-                    }
-                    if (excludeMethodFilters != null && MethodFilter.matchesClassName(excludeMethodFilters, className)) {
-                        continue;
-                    }
-
                     if (className.startsWith("jdk.management.") || className.startsWith("jdk.internal.cmm.*")) {
                         continue;
                     }
@@ -581,6 +574,17 @@ public final class CompileTheWorld {
                         } catch (Throwable t) {
                             // If something went wrong during pre-loading we just ignore it.
                             println("Preloading failed for (%d) %s: %s", classFileCounter, className, t);
+                        }
+
+                        /*
+                         * Only check filters after class loading and resolution to mitigate impact
+                         * on reproducibility.
+                         */
+                        if (methodFilters != null && !MethodFilter.matchesClassName(methodFilters, className)) {
+                            continue;
+                        }
+                        if (excludeMethodFilters != null && MethodFilter.matchesClassName(excludeMethodFilters, className)) {
+                            continue;
                         }
 
                         // Are we compiling this class?


### PR DESCRIPTION
The method filters can help reproducing a failure quickly but they also change which classes are loaded which impairs reproducibility.  Instead we should perform exactly the same loading but stop before compiling them.