### PR TITLE
parallel gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ install:
   - |
       if [ "$JDK" == "jdk9" ]
       then
-        JDK_TAR=$TRAVIS_BUILD_DIR/../jdk9-SNAPSHOT-fastdebug-linux-amd64.tar.gz
-        wget https://lafo.ssw.uni-linz.ac.at/slavefiles/jdk/jdk9-SNAPSHOT-fastdebug-linux-amd64.tar.gz -O $JDK_TAR
+        JDK_TAR=$TRAVIS_BUILD_DIR/../jdk9-SNAPSHOT-release-linux-amd64.tar.gz
+        wget https://lafo.ssw.uni-linz.ac.at/slavefiles/jdk/jdk9-SNAPSHOT-release-linux-amd64.tar.gz -O $JDK_TAR
         tar -C $TRAVIS_BUILD_DIR/.. -xf $JDK_TAR
         export JAVA_HOME=$TRAVIS_BUILD_DIR/../jdk1.9.0
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ env:
     - DEFAULT_VM="jvmci"
     - MX_BINARY_SUITES="jvmci,truffle"
   matrix:
-    - JDK="jdk8" GATE="build,style,test"
+    - GATE="style"
+    - GATE="fullbuild"
+    - JDK="jdk8" GATE="build,test"
+    - JDK="jdk8" GATE="build,bootstrap"
     - JDK="jdk9" GATE="build,test"
+    - JDK="jdk9" GATE="build,bootstrap"
 install:
   - |
       export MX_PATH=$TRAVIS_BUILD_DIR/../mx
@@ -37,13 +41,16 @@ install:
         pip install astroid==1.1.0
         pip install pylint==1.1.0
 
-        export JDT=$MX_PATH/ecj.jar
-        wget http://ftp.halifax.rwth-aachen.de/eclipse//eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar -O $JDT
-
         export ECLIPSE_TAR=$TRAVIS_BUILD_DIR/../eclipse.tar.gz
         wget https://lafo.ssw.uni-linz.ac.at/slavefiles/gate/eclipse-jdk8-linux-x86_64.tar.gz -O $ECLIPSE_TAR
         tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
         export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
+      fi
+  - |
+      if [[ $GATE == *fullbuild* ]]
+      then
+        export JDT=$MX_PATH/ecj.jar
+        wget http://ftp.halifax.rwth-aachen.de/eclipse//eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar -O $JDT
       fi
   - |
       if [ "$JDK" == "jdk9" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ env:
     - DEFAULT_VM="jvmci"
     - MX_BINARY_SUITES="jvmci,truffle"
   matrix:
-    - GATE="style"
-    - GATE="fullbuild"
+    - GATE="style,fullbuild"
     - JDK="jdk8" GATE="build,test"
     - JDK="jdk8" GATE="build,bootstrap"
     - JDK="jdk9" GATE="build,test"

--- a/mx.graal-core/mx_graal_8.py
+++ b/mx.graal-core/mx_graal_8.py
@@ -34,7 +34,7 @@ import mx
 from mx_jvmci import JVMCI_VERSION, JvmciJDKDeployedDist, JVMCIArchiveParticipant, jdkDeployedDists, add_bootclasspath_prepend, buildvms, get_jvmci_jdk, _JVMCI_JDK_TAG, VM, relativeVmLibDirInJdk, isJVMCIEnabled
 from mx_jvmci import get_vm as _jvmci_get_vm
 from mx_jvmci import run_vm as _jvmci_run_vm
-from mx_gate import Task, Tags
+from mx_gate import Task
 from sanitycheck import _noneAsEmptyList
 
 from mx_unittest import unittest
@@ -256,12 +256,13 @@ class MicrobenchRun:
 
 class GraalTags:
     test = 'test'
+    bootstrap = 'bootstrap'
     fulltest = 'fulltest'
 
 def compiler_gate_runner(suites, unit_test_runs, bootstrap_tests, tasks, extraVMarguments=None):
 
     # Build server-hosted-jvmci now so we can run the unit tests
-    with Task('BuildHotSpotGraalHosted: product', tasks, tags=[Tags.build]) as t:
+    with Task('BuildHotSpotGraalHosted: product', tasks, tags=[GraalTags.test, GraalTags.fulltest]) as t:
         if t: buildvms(['--vms', 'server', '--builds', 'product'])
 
     with VM('server', 'product'):
@@ -280,8 +281,10 @@ def compiler_gate_runner(suites, unit_test_runs, bootstrap_tests, tasks, extraVM
             if t: ctw(['--ctwopts', '-Inline +ExitVMOnException', '-esa', '-G:+CompileTheWorldMultiThreaded', '-G:-InlineDuringParsing', '-G:-CompileTheWorldVerbose', '-XX:ReservedCodeCacheSize=400m'], _noneAsEmptyList(extraVMarguments))
 
     # Build the jvmci VMs so we can run the other tests
-    with Task('BuildHotSpotGraalOthers: fastdebug,product', tasks, tags=[Tags.build]) as t:
-        if t: buildvms(['--vms', 'jvmci', '--builds', 'fastdebug,product'])
+    with Task('BuildHotSpotGraalJVMCI: fastdebug', tasks, tags=[GraalTags.bootstrap, GraalTags.fulltest]) as t:
+        if t: buildvms(['--vms', 'jvmci', '--builds', 'fastdebug'])
+    with Task('BuildHotSpotGraalJVMCI: product', tasks, tags=[GraalTags.fulltest]) as t:
+        if t: buildvms(['--vms', 'jvmci', '--builds', 'product'])
 
     # bootstrap tests
     for b in bootstrap_tests:
@@ -318,7 +321,7 @@ graal_unit_test_runs = [
 _registers = 'o0,o1,o2,o3,f8,f9,d32,d34' if mx.get_arch() == 'sparcv9' else 'rbx,r11,r10,r14,xmm3,xmm11,xmm14'
 
 graal_bootstrap_tests = [
-    BootstrapTest('BootstrapWithSystemAssertions', 'fastdebug', ['-esa'], tags=[GraalTags.test]),
+    BootstrapTest('BootstrapWithSystemAssertions', 'fastdebug', ['-esa'], tags=[GraalTags.bootstrap]),
     BootstrapTest('BootstrapWithSystemAssertionsNoCoop', 'fastdebug', ['-esa', '-XX:-UseCompressedOops', '-G:+ExitVMOnException'], tags=[GraalTags.fulltest]),
     BootstrapTest('BootstrapWithGCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], tags=[GraalTags.fulltest], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),
     BootstrapTest('BootstrapWithG1GCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:-UseSerialGC', '-XX:+UseG1GC', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], tags=[GraalTags.fulltest], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),

--- a/mx.graal-core/mx_graal_9.py
+++ b/mx.graal-core/mx_graal_9.py
@@ -240,6 +240,7 @@ class MicrobenchRun:
 
 class GraalTags:
     test = 'test'
+    bootstrap = 'bootstrap'
     fulltest = 'fulltest'
 
 def compiler_gate_runner(suites, unit_test_runs, bootstrap_tests, tasks, extraVMarguments=None):
@@ -293,7 +294,7 @@ graal_unit_test_runs = [
 _registers = 'o0,o1,o2,o3,f8,f9,d32,d34' if mx.get_arch() == 'sparcv9' else 'rbx,r11,r10,r14,xmm3,xmm11,xmm14'
 
 graal_bootstrap_tests = [
-    BootstrapTest('BootstrapWithSystemAssertions', 'fastdebug', ['-esa'], tags=[GraalTags.test]),
+    BootstrapTest('BootstrapWithSystemAssertions', 'fastdebug', ['-esa'], tags=[GraalTags.bootstrap]),
     BootstrapTest('BootstrapWithSystemAssertionsNoCoop', 'fastdebug', ['-esa', '-XX:-UseCompressedOops', '-G:+ExitVMOnException'], tags=[GraalTags.fulltest]),
     BootstrapTest('BootstrapWithGCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], tags=[GraalTags.fulltest], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),
     BootstrapTest('BootstrapWithG1GCVerification', 'product', ['-XX:+UnlockDiagnosticVMOptions', '-XX:-UseSerialGC', '-XX:+UseG1GC', '-XX:+VerifyBeforeGC', '-XX:+VerifyAfterGC', '-G:+ExitVMOnException'], tags=[GraalTags.fulltest], suppress=['VerifyAfterGC:', 'VerifyBeforeGC:']),

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -31,7 +31,7 @@ def suites(l):
     return [s for s in l if not JDK9 or not s.get('name') == "jvmci"]
 
 suite = {
-  "mxversion" : "5.7.0",
+  "mxversion" : "5.8.1",
   "name" : "graal-core",
 
   "imports" : {


### PR DESCRIPTION
Parallelizes the gate into 6 separate runs:
- style checks
- ecj build / warnings / findbugs
- unit tests on jdk8
- bootstrap on jdk8
- unit tests on jdk9
- bootstrap on jdk9

Only the `BuildJavaWithJavac` step is running in 5 of these 6 gates, everything else is non-overlapping.

~~DO NOT MERGE YET, this is relying on a not yet merged mx feature.~~