### PR TITLE
LogicNodes are indirectly canonicalizable

### DIFF
--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/LogicNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/LogicNode.java
@@ -26,11 +26,12 @@ import static com.oracle.graal.nodeinfo.InputType.Condition;
 
 import com.oracle.graal.compiler.common.type.StampFactory;
 import com.oracle.graal.graph.NodeClass;
+import com.oracle.graal.graph.Node.IndirectCanonicalization;
 import com.oracle.graal.nodeinfo.NodeInfo;
 import com.oracle.graal.nodes.calc.FloatingNode;
 
 @NodeInfo(allowedUsageTypes = {Condition})
-public abstract class LogicNode extends FloatingNode {
+public abstract class LogicNode extends FloatingNode implements IndirectCanonicalization {
 
     public static final NodeClass<LogicNode> TYPE = NodeClass.create(LogicNode.class);
 


### PR DESCRIPTION
Changes to the inputs of a LogicNode should trigger canonicalization of its users.