### PR TITLE
Use ArithmeticOperation as common superinterface for nodes that use the ArithmeticOpTable mechanism.

### DIFF
--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/ArithmeticOperation.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/ArithmeticOperation.java
@@ -22,9 +22,13 @@
  */
 package com.oracle.graal.nodes;
 
+import com.oracle.graal.compiler.common.type.ArithmeticOpTable.Op;
+
 /**
  * An {@code ArithmeticOperation} is an operation that does primitive value arithmetic without side
  * effect.
  */
 public interface ArithmeticOperation {
+
+    Op getArithmeticOp();
 }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/BinaryArithmeticNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/BinaryArithmeticNode.java
@@ -38,6 +38,7 @@ import com.oracle.graal.graph.iterators.NodePredicate;
 import com.oracle.graal.graph.spi.Canonicalizable;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
 import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.ArithmeticOperation;
 import com.oracle.graal.nodes.ConstantNode;
 import com.oracle.graal.nodes.StructuredGraph;
 import com.oracle.graal.nodes.ValueNode;
@@ -45,7 +46,7 @@ import com.oracle.graal.nodes.spi.ArithmeticLIRLowerable;
 import com.oracle.graal.nodes.spi.NodeValueMap;
 
 @NodeInfo
-public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements ArithmeticLIRLowerable, Canonicalizable.Binary<ValueNode> {
+public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements ArithmeticOperation, ArithmeticLIRLowerable, Canonicalizable.Binary<ValueNode> {
 
     @SuppressWarnings("rawtypes") public static final NodeClass<BinaryArithmeticNode> TYPE = NodeClass.create(BinaryArithmeticNode.class);
 
@@ -65,8 +66,12 @@ public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements Ari
         return getOp.apply(table);
     }
 
+    public final BinaryOp<OP> getArithmeticOp() {
+        return getOp(getX(), getY());
+    }
+
     public boolean isAssociative() {
-        return getOp(getX(), getY()).isAssociative();
+        return getArithmeticOp().isAssociative();
     }
 
     @Override
@@ -89,7 +94,7 @@ public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements Ari
     @Override
     public Stamp foldStamp(Stamp stampX, Stamp stampY) {
         assert stampX.isCompatible(x.stamp()) && stampY.isCompatible(y.stamp());
-        return getOp(getX(), getY()).foldStamp(stampX, stampY);
+        return getArithmeticOp().foldStamp(stampX, stampY);
     }
 
     public static AddNode add(StructuredGraph graph, ValueNode v1, ValueNode v2) {

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/ConvertNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/ConvertNode.java
@@ -27,13 +27,12 @@ import jdk.vm.ci.meta.ConstantReflectionProvider;
 
 import com.oracle.graal.compiler.common.calc.Condition;
 import com.oracle.graal.graph.NodeInterface;
-import com.oracle.graal.nodes.ArithmeticOperation;
 import com.oracle.graal.nodes.ValueNode;
 
 /**
  * Represents a conversion between primitive types.
  */
-public interface ConvertNode extends ArithmeticOperation, NodeInterface {
+public interface ConvertNode extends NodeInterface {
 
     ValueNode getValue();
 

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/FloatConvertNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/FloatConvertNode.java
@@ -77,7 +77,7 @@ public final class FloatConvertNode extends UnaryArithmeticNode<FloatConvertOp> 
 
     @Override
     public Constant convert(Constant c, ConstantReflectionProvider constantReflection) {
-        return getOp(getValue()).foldConstant(c);
+        return getArithmeticOp().foldConstant(c);
     }
 
     @Override

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/IntegerConvertNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/IntegerConvertNode.java
@@ -35,6 +35,7 @@ import com.oracle.graal.compiler.common.type.Stamp;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
 import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.ArithmeticOperation;
 import com.oracle.graal.nodes.ConstantNode;
 import com.oracle.graal.nodes.StructuredGraph;
 import com.oracle.graal.nodes.ValueNode;
@@ -44,7 +45,7 @@ import com.oracle.graal.nodes.spi.ArithmeticLIRLowerable;
  * An {@code IntegerConvert} converts an integer to an integer of different width.
  */
 @NodeInfo
-public abstract class IntegerConvertNode<OP, REV> extends UnaryNode implements ConvertNode, ArithmeticLIRLowerable {
+public abstract class IntegerConvertNode<OP, REV> extends UnaryNode implements ArithmeticOperation, ConvertNode, ArithmeticLIRLowerable {
     @SuppressWarnings("rawtypes") public static final NodeClass<IntegerConvertNode> TYPE = NodeClass.create(IntegerConvertNode.class);
 
     protected final SerializableIntegerConvertFunction<OP> getOp;
@@ -77,9 +78,13 @@ public abstract class IntegerConvertNode<OP, REV> extends UnaryNode implements C
         return getOp.apply(ArithmeticOpTable.forStamp(forValue.stamp()));
     }
 
+    public final IntegerConvertOp<OP> getArithmeticOp() {
+        return getOp(getValue());
+    }
+
     @Override
     public Constant convert(Constant c, ConstantReflectionProvider constantReflection) {
-        return getOp(getValue()).foldConstant(getInputBits(), getResultBits(), c);
+        return getArithmeticOp().foldConstant(getInputBits(), getResultBits(), c);
     }
 
     @Override
@@ -91,7 +96,7 @@ public abstract class IntegerConvertNode<OP, REV> extends UnaryNode implements C
     @Override
     public Stamp foldStamp(Stamp newStamp) {
         assert newStamp.isCompatible(getValue().stamp());
-        return getOp(getValue()).foldStamp(inputBits, resultBits, newStamp);
+        return getArithmeticOp().foldStamp(inputBits, resultBits, newStamp);
     }
 
     @Override

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/ShiftNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/ShiftNode.java
@@ -36,6 +36,7 @@ import com.oracle.graal.compiler.common.type.Stamp;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
 import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.ArithmeticOperation;
 import com.oracle.graal.nodes.ConstantNode;
 import com.oracle.graal.nodes.ValueNode;
 import com.oracle.graal.nodes.spi.ArithmeticLIRLowerable;
@@ -44,7 +45,7 @@ import com.oracle.graal.nodes.spi.ArithmeticLIRLowerable;
  * The {@code ShiftOp} class represents shift operations.
  */
 @NodeInfo
-public abstract class ShiftNode<OP> extends BinaryNode implements ArithmeticLIRLowerable, NarrowableArithmeticNode {
+public abstract class ShiftNode<OP> extends BinaryNode implements ArithmeticOperation, ArithmeticLIRLowerable, NarrowableArithmeticNode {
 
     @SuppressWarnings("rawtypes") public static final NodeClass<ShiftNode> TYPE = NodeClass.create(ShiftNode.class);
 
@@ -69,9 +70,13 @@ public abstract class ShiftNode<OP> extends BinaryNode implements ArithmeticLIRL
         return getOp.apply(ArithmeticOpTable.forStamp(forValue.stamp()));
     }
 
+    public final ShiftOp<OP> getArithmeticOp() {
+        return getOp(getX());
+    }
+
     @Override
     public Stamp foldStamp(Stamp stampX, Stamp stampY) {
-        return getOp(getX()).foldStamp(stampX, (IntegerStamp) stampY);
+        return getArithmeticOp().foldStamp(stampX, (IntegerStamp) stampY);
     }
 
     @Override
@@ -85,7 +90,7 @@ public abstract class ShiftNode<OP> extends BinaryNode implements ArithmeticLIRL
     }
 
     public int getShiftAmountMask() {
-        return getOp(getX()).getShiftAmountMask(stamp());
+        return getArithmeticOp().getShiftAmountMask(stamp());
     }
 
     public boolean isNarrowable(int resultBits) {

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/UnaryArithmeticNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/UnaryArithmeticNode.java
@@ -31,12 +31,13 @@ import com.oracle.graal.compiler.common.type.Stamp;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
 import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.ArithmeticOperation;
 import com.oracle.graal.nodes.ConstantNode;
 import com.oracle.graal.nodes.ValueNode;
 import com.oracle.graal.nodes.spi.ArithmeticLIRLowerable;
 
 @NodeInfo
-public abstract class UnaryArithmeticNode<OP> extends UnaryNode implements ArithmeticLIRLowerable {
+public abstract class UnaryArithmeticNode<OP> extends UnaryNode implements ArithmeticOperation, ArithmeticLIRLowerable {
 
     @SuppressWarnings("rawtypes") public static final NodeClass<UnaryArithmeticNode> TYPE = NodeClass.create(UnaryArithmeticNode.class);
 
@@ -52,6 +53,10 @@ public abstract class UnaryArithmeticNode<OP> extends UnaryNode implements Arith
 
     protected final UnaryOp<OP> getOp(ValueNode forValue) {
         return getOp.apply(ArithmeticOpTable.forStamp(forValue.stamp()));
+    }
+
+    public final UnaryOp<OP> getArithmeticOp() {
+        return getOp(getValue());
     }
 
     @Override

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/spi/ArithmeticLIRLowerable.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/spi/ArithmeticLIRLowerable.java
@@ -23,9 +23,8 @@
 package com.oracle.graal.nodes.spi;
 
 import com.oracle.graal.lir.gen.ArithmeticLIRGeneratorTool;
-import com.oracle.graal.nodes.ArithmeticOperation;
 
-public interface ArithmeticLIRLowerable extends ArithmeticOperation, LIRLowerable {
+public interface ArithmeticLIRLowerable extends LIRLowerable {
 
     default void generate(NodeLIRBuilderTool builder) {
         generate(builder, builder.getLIRGeneratorTool().getArithmetic());


### PR DESCRIPTION
There was no common superinterface for the nodes using the `ArithmeticOpTable` mechanism of type-independent stamp and constant folding, and therefore no way to get the `Op` descriptor.

The old `ArithmeticOperation` interface is a nice place to put this. This means that some nodes that used to be `ArithmeticOperation` are now not (e.g. `AMD64MathIntrinsicNode`). On the other hand, the old `ArithmeticOperation` interface was redundant anyway, there was not a single class that implemented `ArithmeticOperation` but not its subinterface `ArithmeticLIRLowerable`.

The new design is more flexible, compiler phases can now directly query the `Op` from nodes that support it, instead of relying on the functionality explicitly exposed by the node via special methods like `foldStamp` or `tryConstantFold`, in case we want to add more type-dependent optimizations.

/cc @dougxc 