### PR TITLE
Make CompiledExceptionHandlerTest more robust.

### DIFF
--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/CompiledExceptionHandlerTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/CompiledExceptionHandlerTest.java
@@ -64,9 +64,17 @@ public class CompiledExceptionHandlerTest extends GraalCompilerTest {
 
             public InlineInfo shouldInlineInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args, JavaType returnType) {
                 if (method.getName().startsWith("raiseException")) {
+                    /*
+                     * Make sure the raiseException* method invokes are not inlined and compiled
+                     * with explicit exception handler.
+                     */
                     return InlineInfo.DO_NOT_INLINE_WITH_EXCEPTION;
                 } else {
-                    return null;
+                    /*
+                     * We don't care whether other invokes are inlined or not, but we definitely
+                     * don't want another explicit exception handler in the graph.
+                     */
+                    return InlineInfo.DO_NOT_INLINE_NO_EXCEPTION;
                 }
             }
         });


### PR DESCRIPTION
Sometimes the test still failed because of random inlining decisions creating a second execption handler (e.g. in one of the StringBuilder methods).