### PR TITLE
Overriding of -XX:-Inline with Graal options isn't working properly

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/CompilationTask.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/CompilationTask.java
@@ -181,9 +181,12 @@ public class CompilationTask {
             try (Scope s = Debug.scope("Compiling", new DebugDumpScope(String.valueOf(getId()), true))) {
                 // Begin the compilation event.
                 compilationEvent.begin();
-                // Use HotSpot's Inline flag if Graal's flag has the default setting
-                boolean inline = Inline.hasDefaultValue() ? config.inline : Inline.getValue();
-                try (OverrideScope s1 = OptionValue.override(Inline, inline)) {
+                /*
+                 * Disable inlining if HotSpot has it disabled unless it's been explicitly set in
+                 * Graal.
+                 */
+                boolean disableInlining = !config.inline && !Inline.hasBeenSet();
+                try (OverrideScope s1 = disableInlining ? OptionValue.override(Inline, false) : null) {
                     result = compiler.compile(method, entryBCI, useProfilingInfo);
                 }
             } catch (Throwable e) {

--- a/graal/com.oracle.graal.options/src/com/oracle/graal/options/OptionValue.java
+++ b/graal/com.oracle.graal.options/src/com/oracle/graal/options/OptionValue.java
@@ -86,9 +86,7 @@ public class OptionValue<T> {
             Entry<OptionValue<?>, Object> single = overrides.entrySet().iterator().next();
             OptionValue<?> option = single.getKey();
             Object overrideValue = single.getValue();
-            if (!overrideValue.equals(option.getValue())) {
-                return new SingleOverrideScope(option, overrideValue);
-            }
+            return new SingleOverrideScope(option, overrideValue);
         }
         return new MultipleOverridesScope(current, overrides);
     }
@@ -259,6 +257,25 @@ public class OptionValue<T> {
     }
 
     /**
+     * Returns true if the option has been set in any way. Note that this doesn't mean that the
+     * current value is different than the default.
+     */
+    public boolean hasBeenSet() {
+        if (!(this instanceof StableOptionValue)) {
+            getValue(); // ensure initialized
+
+            OverrideScope overrideScope = getOverrideScope();
+            if (overrideScope != null) {
+                T override = overrideScope.getOverride(this);
+                if (override != null) {
+                    return true;
+                }
+            }
+        }
+        return value != DEFAULT;
+    }
+
+    /**
      * Gets the value of this option.
      */
     public T getValue() {
@@ -420,9 +437,7 @@ public class OptionValue<T> {
                 if (option instanceof StableOptionValue) {
                     throw new IllegalArgumentException("Cannot override stable option " + option);
                 }
-                if (!e.getValue().equals(option.getValue())) {
-                    this.overrides.put(option, e.getValue());
-                }
+                this.overrides.put(option, e.getValue());
             }
             if (!this.overrides.isEmpty()) {
                 setOverrideScope(this);


### PR DESCRIPTION
This seems to be the cause of the ctw failures.  The changes to respect -XX:-Inline relied on hasDefaultValue but CTW overrides the Graal inline flag when run from the gate.  We weren't detecting that override anymore so compiling everything with inlining.  We still have debug why it fails.  