### PR TITLE
Disable BC_{df}rem unittests on SPARC temporarily

### DIFF
--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_drem.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_drem.java
@@ -23,6 +23,9 @@
 
 package com.oracle.graal.jtt.bytecode;
 
+import static org.junit.Assume.assumeFalse;
+import jdk.vm.ci.sparc.SPARC;
+
 import org.junit.Test;
 
 public class BC_drem extends BC_ddiv_drem_base {
@@ -33,6 +36,7 @@ public class BC_drem extends BC_ddiv_drem_base {
 
     @Test
     public void drem() {
+        assumeFalse("Skipping test on SPARC which is known not working. See  https://github.com/graalvm/graal-core/issues/46", getTarget().arch instanceof SPARC);
         runTest("test", x, y);
     }
 

--- a/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_frem.java
+++ b/graal/com.oracle.graal.jtt/src/com/oracle/graal/jtt/bytecode/BC_frem.java
@@ -23,6 +23,9 @@
 
 package com.oracle.graal.jtt.bytecode;
 
+import static org.junit.Assume.assumeFalse;
+import jdk.vm.ci.sparc.SPARC;
+
 import org.junit.Test;
 
 public class BC_frem extends BC_fdiv_frem_base {
@@ -33,7 +36,7 @@ public class BC_frem extends BC_fdiv_frem_base {
 
     @Test
     public void frem() {
+        assumeFalse("Skipping test on SPARC which is known not working. See  https://github.com/graalvm/graal-core/issues/46", getTarget().arch instanceof SPARC);
         runTest("test", x, y);
     }
-
 }


### PR DESCRIPTION
Issue #30 will be fixed soon, until then, I've disabled the offending unittests.