### PR TITLE
CompileTheWorld now includes class initializers (i.e., <clinit>).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog summarizes major changes between Graal versions relevant to developers building technology on top of Graal. The main focus is on APIs exported by Graal but other significant performance/stability changes are mentioned as well.
 
+## `tip`
+* CompileTheWorld now includes class initializers.
+
 ## Version 0.12
 * Added initial code for AArch64 port.
 * Moved @ServiceProvider mechanism from JVMCI to Graal.

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/CompileTheWorld.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/CompileTheWorld.java
@@ -279,7 +279,11 @@ public final class CompileTheWorld {
     }
 
     public void println(String s) {
-        if (verbose) {
+        println(verbose, s);
+    }
+
+    public static void println(boolean cond, String s) {
+        if (cond) {
             TTY.println(s);
         }
     }
@@ -726,8 +730,10 @@ public final class CompileTheWorld {
         }
         HotSpotVMConfig c = config();
         if (c.dontCompileHugeMethods && javaMethod.getCodeSize() > c.hugeMethodLimit) {
-            println("CompileTheWorld (%d) : Skipping huge method %s (use -XX:-DontCompileHugeMethods or -XX:HugeMethodLimit=%d to include it)", classFileCounter, javaMethod.format("%H.%n(%p):%r"),
-                            javaMethod.getCodeSize());
+            println(verbose || methodFilters != null,
+                            String.format("CompileTheWorld (%d) : Skipping huge method %s (use -XX:-DontCompileHugeMethods or -XX:HugeMethodLimit=%d to include it)", classFileCounter,
+                                            javaMethod.format("%H.%n(%p):%r"),
+                                            javaMethod.getCodeSize()));
             return false;
         }
         // Allow use of -XX:CompileCommand=dontinline to exclude problematic methods


### PR DESCRIPTION
While most uses of Graal won't ever compile class initializers, it's still possible and so we should stress it.