### PR TITLE
fix NFI when used from the truffle partial evaluator

### DIFF
--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -1534,9 +1534,10 @@ public class BytecodeParser implements GraphBuilderContext {
         return null;
     }
 
-    public void intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args) {
+    public boolean intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args) {
         boolean res = inline(targetMethod, substitute, true, args);
         assert res : "failed to inline " + substitute;
+        return res;
     }
 
     private boolean inline(ResolvedJavaMethod targetMethod, ResolvedJavaMethod inlinedMethod, boolean isIntrinsic, ValueNode[] args) {

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/graphbuilderconf/GraphBuilderContext.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/graphbuilderconf/GraphBuilderContext.java
@@ -144,8 +144,9 @@ public interface GraphBuilderContext {
      * @param targetMethod the method being intrinsified
      * @param substitute the intrinsic implementation
      * @param args the arguments with which to inline the invocation
+     * @return whether the intrinsification was successful
      */
-    void intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args);
+    boolean intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args);
 
     StampProvider getStampProvider();
 

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/graphbuilderconf/MethodSubstitutionPlugin.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/graphbuilderconf/MethodSubstitutionPlugin.java
@@ -171,8 +171,7 @@ public final class MethodSubstitutionPlugin implements InvocationPlugin {
         if (receiver != null) {
             receiver.get();
         }
-        b.intrinsify(targetMethod, subst, argsIncludingReceiver);
-        return true;
+        return b.intrinsify(targetMethod, subst, argsIncludingReceiver);
     }
 
     public StackTraceElement getApplySourceLocation(MetaAccessProvider metaAccess) {

--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/DerivedOopTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/DerivedOopTest.java
@@ -143,8 +143,7 @@ public class DerivedOopTest extends GraalCompilerTest implements Snippets {
         ResolvedJavaMethod intrinsic = getResolvedJavaMethod("getRawPointerIntrinsic");
         r.register1("getRawPointer", Object.class, new InvocationPlugin() {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode arg) {
-                b.intrinsify(targetMethod, intrinsic, new ValueNode[]{arg});
-                return true;
+                return b.intrinsify(targetMethod, intrinsic, new ValueNode[]{arg});
             }
         });
 

--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/PointerTrackingTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/PointerTrackingTest.java
@@ -121,8 +121,7 @@ public class PointerTrackingTest extends GraalCompilerTest implements Snippets {
         ResolvedJavaMethod intrinsic = getResolvedJavaMethod(fnName + "Intrinsic");
         r.register1(fnName, Object.class, new InvocationPlugin() {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode arg) {
-                b.intrinsify(targetMethod, intrinsic, new ValueNode[]{arg});
-                return true;
+                return b.intrinsify(targetMethod, intrinsic, new ValueNode[]{arg});
             }
         });
     }

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/IntrinsicGraphBuilder.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/IntrinsicGraphBuilder.java
@@ -231,7 +231,7 @@ public class IntrinsicGraphBuilder implements GraphBuilderContext, Receiver {
         return null;
     }
 
-    public void intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args) {
+    public boolean intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args) {
         throw JVMCIError.shouldNotReachHere();
     }
 

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
@@ -229,8 +229,8 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         }
 
         @Override
-        public void intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args) {
-            throw unimplemented();
+        public boolean intrinsify(ResolvedJavaMethod targetMethod, ResolvedJavaMethod substitute, ValueNode[] args) {
+            return false;
         }
 
         @Override

--- a/graal/com.oracle.graal.truffle.hotspot.test/src/com/oracle/graal/truffle/hotspot/test/PENativeFunctionInterfaceTest.java
+++ b/graal/com.oracle.graal.truffle.hotspot.test/src/com/oracle/graal/truffle/hotspot/test/PENativeFunctionInterfaceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.truffle.hotspot.test;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.oracle.graal.truffle.test.PartialEvaluationTest;
+import com.oracle.graal.truffle.test.nodes.AbstractTestNode;
+import com.oracle.graal.truffle.test.nodes.ConstantTestNode;
+import com.oracle.graal.truffle.test.nodes.RootTestNode;
+import com.oracle.nfi.NativeFunctionInterfaceRuntime;
+import com.oracle.nfi.api.NativeFunctionHandle;
+import com.oracle.nfi.api.NativeFunctionInterface;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+
+public class PENativeFunctionInterfaceTest extends PartialEvaluationTest {
+
+    @NodeInfo
+    static class NativeSqrtNode extends AbstractTestNode {
+
+        private final NativeFunctionHandle sqrt;
+
+        @Child private AbstractTestNode value;
+
+        NativeSqrtNode(NativeFunctionInterface nfi, AbstractTestNode value) {
+            this.sqrt = nfi.getFunctionHandle("sqrt", double.class, double.class);
+            this.value = value;
+        }
+
+        @Override
+        public int execute(VirtualFrame frame) {
+            double ret = (Double) sqrt.call((double) value.execute(frame));
+            return (int) ret;
+        }
+
+    }
+
+    @Test
+    public void testSqrt() {
+        NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
+        Assume.assumeTrue("NFI not supported on this platform", nfi != null);
+
+        AbstractTestNode input = new ConstantTestNode(42);
+        AbstractTestNode sqrt = new NativeSqrtNode(nfi, input);
+        RootTestNode root = new RootTestNode(new FrameDescriptor(), "nativeSqrt", sqrt);
+
+        assertPartialEvalNoInvokes(root);
+    }
+}

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
@@ -125,7 +125,7 @@ public class PartialEvaluator {
         }
 
         this.configForParsing = createGraphBuilderConfig(configForRoot, true);
-        this.decodingInvocationPlugins = createDecodingInvocationPlugins();
+        this.decodingInvocationPlugins = createDecodingInvocationPlugins(configForRoot.getPlugins());
     }
 
     public Providers getProviders() {
@@ -383,9 +383,9 @@ public class PartialEvaluator {
         }
     }
 
-    protected InvocationPlugins createDecodingInvocationPlugins() {
+    protected InvocationPlugins createDecodingInvocationPlugins(Plugins parent) {
         @SuppressWarnings("hiding")
-        InvocationPlugins decodingInvocationPlugins = new InvocationPlugins(providers.getMetaAccess());
+        InvocationPlugins decodingInvocationPlugins = new InvocationPlugins(parent.getInvocationPlugins());
         registerTruffleInvocationPlugins(decodingInvocationPlugins, false);
         decodingInvocationPlugins.closeRegistration();
         return decodingInvocationPlugins;

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -1094,7 +1094,7 @@ suite = {
       "sourceDirs" : ["src"],
       "dependencies" : [
         "com.oracle.graal.truffle.hotspot",
-        "com.oracle.graal.compiler.test",
+        "com.oracle.graal.truffle.test",
       ],
       "checkstyle" : "com.oracle.graal.graph",
       "javaCompliance" : "1.8",


### PR DESCRIPTION
The partial evaluator didn't run the normal Graal invocation plugins like a standard Java compilation. Since the NFI plugin can't do anything useful when the function is not yet constant, it needs to be re-run during partial evaluation.

This PR also contains a unit test demonstrating the problem. It also includes an update of the truffle version, since the unit test triggers the NPE of graalvm/truffle#72.