### PR TITLE
Fix problems in graal stack trace handling to match those of the default runtime in the latest version.

### DIFF
--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/InstrumentationPETestLanguage.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/InstrumentationPETestLanguage.java
@@ -33,7 +33,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrument.ASTProber;
 import com.oracle.truffle.api.instrument.EventHandlerNode;
 import com.oracle.truffle.api.instrument.Instrumenter;
-import com.oracle.truffle.api.instrument.KillException;
 import com.oracle.truffle.api.instrument.Probe;
 import com.oracle.truffle.api.instrument.SyntaxTag;
 import com.oracle.truffle.api.instrument.Visualizer;
@@ -100,6 +99,7 @@ public final class InstrumentationPETestLanguage extends TruffleLanguage<Object>
         return false;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Visualizer getVisualizer() {
         return null;
@@ -195,8 +195,6 @@ public final class InstrumentationPETestLanguage extends TruffleLanguage<Object>
             try {
                 result = child.execute(vFrame);
                 eventHandlerNode.returnValue(child, vFrame, result);
-            } catch (KillException e) {
-                throw (e);
             } catch (Exception e) {
                 eventHandlerNode.returnExceptional(child, vFrame, e);
                 throw (e);

--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/builtins/SLGenerateDummyNodesBuiltin.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/builtins/SLGenerateDummyNodesBuiltin.java
@@ -47,7 +47,7 @@ public abstract class SLGenerateDummyNodesBuiltin extends SLGraalRuntimeBuiltin 
     @Specialization
     public Object generateNodes(long count) {
         CompilerAsserts.neverPartOfCompilation("generateNodes should never get optimized.");
-        FrameInstance callerFrame = Truffle.getRuntime().getCallerFrame();
+        FrameInstance callerFrame = Truffle.getRuntime().getCurrentFrame();
         SLRootNode root = (SLRootNode) callerFrame.getCallNode().getRootNode();
         root.getBodyNode().replace(createBinaryTree((int) (count - 1)));
         return SLNull.SINGLETON;

--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/nodes/WrapperTestNode.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/nodes/WrapperTestNode.java
@@ -24,7 +24,6 @@ package com.oracle.graal.truffle.test.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrument.EventHandlerNode;
-import com.oracle.truffle.api.instrument.KillException;
 import com.oracle.truffle.api.instrument.Probe;
 import com.oracle.truffle.api.instrument.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
@@ -66,8 +65,6 @@ public final class WrapperTestNode extends AbstractTestNode implements WrapperNo
             final int result = child.execute(frame);
             eventHandlerNode.returnValue(child, frame, result);
             return result;
-        } catch (KillException e) {
-            throw (e);
         } catch (Exception e) {
             eventHandlerNode.returnExceptional(child, frame, e);
             throw (e);

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -328,7 +328,7 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
     public FrameInstance getCallerFrame() {
         return iterateImpl(frame -> {
             return frame;
-        } , 1);
+        }, 1);
     }
 
     @TruffleBoundary

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -257,14 +257,14 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
         private boolean first = true;
         private int skipFrames;
 
-        public FrameVisitor(FrameInstanceVisitor<T> visitor, CallMethods methods, int skip) {
+        FrameVisitor(FrameInstanceVisitor<T> visitor, CallMethods methods, int skip) {
             this.visitor = visitor;
             this.callTargetMethod = methods.callTargetMethod;
             this.callNodeMethod = methods.callNodeMethod;
             this.skipFrames = skip;
         }
 
-        public final T visitFrame(InspectedFrame frame) {
+        public T visitFrame(InspectedFrame frame) {
             if (nextAvailable) {
                 T result = onNext(frame);
                 if (result != null) {
@@ -326,9 +326,7 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
 
     @Override
     public FrameInstance getCallerFrame() {
-        return iterateImpl(frame -> {
-            return frame;
-        }, 1);
+        return iterateImpl(frame -> frame, 1);
     }
 
     @TruffleBoundary

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -242,43 +242,99 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
 
     @TruffleBoundary
     @Override
-    public <T> T iterateFrames(FrameInstanceVisitor<T> visitor) {
-        StackIntrospection stackIntrospection = getStackIntrospection();
+    public <T> T iterateFrames(final FrameInstanceVisitor<T> visitor) {
+        return iterateImpl(visitor, 0);
+    }
 
-        InspectedFrameVisitor<T> inspectedFrameVisitor = new InspectedFrameVisitor<T>() {
-            private boolean skipNext = false;
+    private static final class FrameVisitor<T> implements InspectedFrameVisitor<T> {
 
-            public T visitFrame(InspectedFrame frame) {
-                if (skipNext) {
-                    assert frame.isMethod(getCallMethods().callTargetMethod[0]);
-                    skipNext = false;
+        private final FrameInstanceVisitor<T> visitor;
+        private final ResolvedJavaMethod callTargetMethod;
+        private final ResolvedJavaMethod callNodeMethod;
+
+        private GraalFrameInstance next;
+        private boolean nextAvailable;
+        private boolean first = true;
+        private int skipFrames;
+
+        public FrameVisitor(FrameInstanceVisitor<T> visitor, CallMethods methods, int skip) {
+            this.visitor = visitor;
+            this.callTargetMethod = methods.callTargetMethod;
+            this.callNodeMethod = methods.callNodeMethod;
+            this.skipFrames = skip;
+        }
+
+        public final T visitFrame(InspectedFrame frame) {
+            if (nextAvailable) {
+                T result = onNext(frame);
+                if (result != null) {
+                    return result;
+                }
+            }
+            if (frame.isMethod(callTargetMethod)) {
+                nextAvailable = true;
+                if (skipFrames == 0) {
+                    GraalFrameInstance graalFrame = new GraalFrameInstance(first);
+                    graalFrame.setCallTargetFrame(frame);
+                    next = graalFrame;
+                }
+                first = false;
+            }
+            return null;
+        }
+
+        private T onNext(InspectedFrame frame) {
+            try {
+                if (skipFrames == 0) {
+                    if (frame != null && frame.isMethod(callNodeMethod)) {
+                        next.setCallNodeFrame(frame);
+                    }
+                    return visitor.visitFrame(next);
+                } else {
+                    skipFrames--;
                     return null;
                 }
-
-                if (frame.isMethod(getCallMethods().callNodeMethod[0])) {
-                    skipNext = true;
-                    return visitor.visitFrame(new GraalFrameInstance.CallNodeFrame(frame));
-                } else {
-                    assert frame.isMethod(getCallMethods().callTargetMethod[0]);
-                    return visitor.visitFrame(new GraalFrameInstance.CallTargetFrame(frame, false));
-                }
-
+            } finally {
+                next = null;
+                nextAvailable = false;
             }
-        };
-        return stackIntrospection.iterateFrames(getCallMethods().anyFrameMethod, getCallMethods().anyFrameMethod, 1, inspectedFrameVisitor);
+        }
+
+        /* Method to collect the last result. */
+        public T afterVisitation() {
+            if (nextAvailable) {
+                return onNext(null);
+            } else {
+                return null;
+            }
+        }
+
+    }
+
+    private <T> T iterateImpl(FrameInstanceVisitor<T> visitor, final int skip) {
+        CallMethods methods = getCallMethods();
+        FrameVisitor<T> jvmciVisitor = new FrameVisitor<>(visitor, methods, skip);
+        T result = getStackIntrospection().iterateFrames(methods.anyFrameMethod, methods.anyFrameMethod, 0, jvmciVisitor);
+        if (result != null) {
+            return result;
+        } else {
+            return jvmciVisitor.afterVisitation();
+        }
     }
 
     protected abstract StackIntrospection getStackIntrospection();
 
     @Override
     public FrameInstance getCallerFrame() {
-        return iterateFrames(frame -> frame);
+        return iterateImpl(frame -> {
+            return frame;
+        } , 1);
     }
 
     @TruffleBoundary
     @Override
     public FrameInstance getCurrentFrame() {
-        return getStackIntrospection().iterateFrames(getCallMethods().callTargetMethod, getCallMethods().callTargetMethod, 0, frame -> new GraalFrameInstance.CallTargetFrame(frame, true));
+        return iterateImpl(frame -> frame, 0);
     }
 
     public <T> T getCapability(Class<T> capability) {
@@ -542,14 +598,14 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
     }
 
     protected static final class CallMethods {
-        public final ResolvedJavaMethod[] callNodeMethod;
-        public final ResolvedJavaMethod[] callTargetMethod;
+        public final ResolvedJavaMethod callNodeMethod;
+        public final ResolvedJavaMethod callTargetMethod;
         public final ResolvedJavaMethod[] anyFrameMethod;
 
         private CallMethods(MetaAccessProvider metaAccess) {
-            this.callNodeMethod = new ResolvedJavaMethod[]{metaAccess.lookupJavaMethod(GraalFrameInstance.CallNodeFrame.METHOD)};
-            this.callTargetMethod = new ResolvedJavaMethod[]{metaAccess.lookupJavaMethod(GraalFrameInstance.CallTargetFrame.METHOD)};
-            this.anyFrameMethod = new ResolvedJavaMethod[]{callNodeMethod[0], callTargetMethod[0]};
+            this.callNodeMethod = metaAccess.lookupJavaMethod(GraalFrameInstance.CALL_NODE_METHOD);
+            this.callTargetMethod = metaAccess.lookupJavaMethod(GraalFrameInstance.CALL_TARGET_METHOD);
+            this.anyFrameMethod = new ResolvedJavaMethod[]{callNodeMethod, callTargetMethod};
         }
 
         public static CallMethods lookup(MetaAccessProvider metaAccess) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
@@ -116,7 +116,7 @@ public class PartialEvaluator {
         this.snippetReflection = snippetReflection;
         this.callDirectMethod = providers.getMetaAccess().lookupJavaMethod(OptimizedCallTarget.getCallDirectMethod());
         this.callInlinedMethod = providers.getMetaAccess().lookupJavaMethod(OptimizedCallTarget.getCallInlinedMethod());
-        this.callSiteProxyMethod = providers.getMetaAccess().lookupJavaMethod(GraalFrameInstance.CallNodeFrame.METHOD);
+        this.callSiteProxyMethod = providers.getMetaAccess().lookupJavaMethod(GraalFrameInstance.CALL_NODE_METHOD);
 
         try {
             callRootMethod = providers.getMetaAccess().lookupJavaMethod(OptimizedCallTarget.class.getDeclaredMethod("callRoot", Object[].class));

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -47,7 +47,7 @@ suite = {
             },
             {
                "name" : "truffle",
-               "version" : "0df57671a11bab09241c3f5a08f9826fd9c658f1",
+               "version" : "da131e23814fb5c7054f0b59a0bf141e56edc0c4",
                "urls" : [
                     {"url" : "https://github.com/graalvm/truffle.git", "kind" : "git"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
This changeset should bring the graal runtime in a compatible state with the default runtime:

Here is the matching Truffle change (needs to get merged before we can push this).
https://github.com/graalvm/truffle/pull/79/files