### PR TITLE
Update jvmci import.

### DIFF
--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -39,7 +39,7 @@ suite = {
             {
                "name" : "jvmci",
                "optional" : "true",
-               "version" : "535ad9410374a8a2f2dbeeaaef15573931e09ecd",
+               "version" : "6758183dd36be0bb56d947f439c8f21822d14ff5",
                "urls" : [
                     {"url" : "http://lafo.ssw.uni-linz.ac.at/hg/graal-jvmci-8", "kind" : "hg"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
Pull in the recent jvmci-8 fix by @eregon 
The port to jvmci-9 is tracked by https://bugs.openjdk.java.net/browse/JDK-8150727 (but since it's an internal change only, there is no hard dependency on that fix).
