### PR TITLE
GraalCompiler: use more precise compilationUnitName if available.

### DIFF
--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/backend/BackendTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/backend/BackendTest.java
@@ -50,7 +50,7 @@ public abstract class BackendTest extends GraalCompilerTest {
             throw Debug.handle(e);
         }
 
-        LIRGenerationResult lirGen = GraalCompiler.emitLIR(getBackend(), graph, null, null, getLIRSuites());
+        LIRGenerationResult lirGen = GraalCompiler.emitLIR(getBackend(), graph, null, null, getLIRSuites(), null);
         return lirGen;
     }
 


### PR DESCRIPTION
This makes compilation unit name more precise, e.g. for Truffle. The code for getting the JavaMethod is similar to the one used in the graph dumper. Is there a better way to do this other than looking in the debug context?

/cc @woess 