### PR TITLE
TraceRA: construct SSI after base pointer marking and clean-ups

### DIFF
--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/BiDirectionalTraceBuilder.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/BiDirectionalTraceBuilder.java
@@ -71,7 +71,7 @@ public final class BiDirectionalTraceBuilder<T extends AbstractBlockBase<T>> {
 
     @SuppressWarnings("try")
     private TraceBuilderResult<T> build(T startBlock) {
-        try (Indent indent = Debug.logAndIndent("start trace building: " + startBlock)) {
+        try (Indent indent = Debug.logAndIndent("start trace building: %s", startBlock)) {
             ArrayList<Trace<T>> traces = buildTraces(startBlock);
             return new TraceBuilderResult<>(traces, blockToTrace);
         }
@@ -98,7 +98,7 @@ public final class BiDirectionalTraceBuilder<T extends AbstractBlockBase<T>> {
     @SuppressWarnings("try")
     private Collection<T> startTrace(T block, int traceNumber) {
         ArrayDeque<T> trace = new ArrayDeque<>();
-        try (Indent i = Debug.logAndIndent("StartTrace: " + block)) {
+        try (Indent i = Debug.logAndIndent("StartTrace: %s", block)) {
             try (Indent indentFront = Debug.logAndIndent("Head:")) {
                 for (T currentBlock = block; currentBlock != null; currentBlock = selectPredecessor(currentBlock)) {
                     addBlockToTrace(currentBlock, traceNumber);

--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/UniDirectionalTraceBuilder.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/UniDirectionalTraceBuilder.java
@@ -78,7 +78,7 @@ public final class UniDirectionalTraceBuilder<T extends AbstractBlockBase<T>> {
 
     @SuppressWarnings("try")
     private TraceBuilderResult<T> build(T startBlock) {
-        try (Indent indent = Debug.logAndIndent("start trace building: " + startBlock)) {
+        try (Indent indent = Debug.logAndIndent("start trace building: %s", startBlock)) {
             ArrayList<Trace<T>> traces = buildTraces(startBlock);
             return new TraceBuilderResult<>(traces, blockToTrace);
         }
@@ -107,7 +107,7 @@ public final class UniDirectionalTraceBuilder<T extends AbstractBlockBase<T>> {
         assert checkPredecessorsProcessed(block);
         ArrayList<T> trace = new ArrayList<>();
         int blockNumber = 0;
-        try (Indent i = Debug.logAndIndent("StartTrace: " + block)) {
+        try (Indent i = Debug.logAndIndent("StartTrace: %s", block)) {
             for (T currentBlock = block; currentBlock != null; currentBlock = selectNext(currentBlock)) {
                 Debug.log("add %s (prob: %f)", currentBlock, currentBlock.probability());
                 processed.set(currentBlock.getId());

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
@@ -48,7 +48,7 @@ import com.oracle.graal.lir.ssi.SSIUtil;
 import com.oracle.graal.lir.ssi.SSIVerifier;
 import com.oracle.graal.options.Option;
 import com.oracle.graal.options.OptionType;
-import com.oracle.graal.options.OptionValue;
+import com.oracle.graal.options.StableOptionValue;
 
 import jdk.vm.ci.code.TargetDescription;
 
@@ -61,13 +61,13 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
     public static class Options {
         // @formatter:off
         @Option(help = "Use inter-trace register hints.", type = OptionType.Debug)
-        public static final OptionValue<Boolean> TraceRAuseInterTraceHints = new OptionValue<>(true);
+        public static final StableOptionValue<Boolean> TraceRAuseInterTraceHints = new StableOptionValue<>(true);
         @Option(help = "Use special allocator for trivial blocks.", type = OptionType.Debug)
-        public static final OptionValue<Boolean> TraceRAtrivialBlockAllocator = new OptionValue<>(true);
+        public static final StableOptionValue<Boolean> TraceRAtrivialBlockAllocator = new StableOptionValue<>(true);
         @Option(help = "Share information about spilled values to other traces.", type = OptionType.Debug)
-        public static final OptionValue<Boolean> TraceRAshareSpillInformation = new OptionValue<>(true);
+        public static final StableOptionValue<Boolean> TraceRAshareSpillInformation = new StableOptionValue<>(true);
         @Option(help = "Reuse spill slots for global move resolution cycle breaking.", type = OptionType.Debug)
-        public static final OptionValue<Boolean> TraceRAreuseStackSlotsForMoveResolutionCycleBreaking = new OptionValue<>(true);
+        public static final StableOptionValue<Boolean> TraceRAreuseStackSlotsForMoveResolutionCycleBreaking = new StableOptionValue<>(true);
         // @formatter:on
     }
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
@@ -100,14 +100,14 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
                     if (trivialTracesMetric.isEnabled() && isTrivialTrace(lir, trace)) {
                         trivialTracesMetric.increment();
                     }
-                    Debug.dump(TRACE_DUMP_LEVEL, trace, "Trace" + trace.getId() + ": " + trace);
+                    Debug.dump(TRACE_DUMP_LEVEL, trace, "Trace%s: %s", trace.getId(), trace);
                     if (Options.TraceRAtrivialBlockAllocator.getValue() && isTrivialTrace(lir, trace)) {
                         TRACE_TRIVIAL_ALLOCATOR.apply(target, lirGenRes, codeEmittingOrder, trace, traceContext, false);
                     } else {
                         TraceLinearScan allocator = new TraceLinearScan(target, lirGenRes, spillMoveFactory, registerAllocationConfig, trace, resultTraces, false);
                         allocator.allocate(target, lirGenRes, codeEmittingOrder, linearScanOrder, spillMoveFactory, registerAllocationConfig);
                     }
-                    Debug.dump(TRACE_DUMP_LEVEL, trace, "After Trace" + trace.getId() + ": " + trace);
+                    Debug.dump(TRACE_DUMP_LEVEL, trace, "After  Trace%s: %s", trace.getId(), trace);
                 }
                 unnumberInstructions(trace.getBlocks(), lir);
             }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanAssignLocationsPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanAssignLocationsPhase.java
@@ -199,6 +199,15 @@ final class TraceLinearScanAssignLocationsPhase extends TraceLinearScanAllocatio
             }
         }
 
+        private final InstructionValueProcedure assignProc = new InstructionValueProcedure() {
+            public Value doValue(LIRInstruction instruction, Value value, OperandMode mode, EnumSet<OperandFlag> flags) {
+                if (isVariable(value)) {
+                    return colorLirOperand(instruction, (Variable) value, mode);
+                }
+                return value;
+            }
+        };
+
         /**
          * Assigns the operand of an {@link LIRInstruction}.
          *
@@ -217,7 +226,6 @@ final class TraceLinearScanAssignLocationsPhase extends TraceLinearScanAllocatio
                 }
             }
 
-            InstructionValueProcedure assignProc = (inst, operand, mode, flags) -> isVariable(operand) ? colorLirOperand(inst, (Variable) operand, mode) : operand;
             // remove useless moves
             if (op instanceof MoveOp) {
                 AllocatableValue result = ((MoveOp) op).getResult();
@@ -267,7 +275,7 @@ final class TraceLinearScanAssignLocationsPhase extends TraceLinearScanAllocatio
             }
         }
 
-        private InstructionValueProcedure colorOutgoingIncomingValues = new InstructionValueProcedure() {
+        private final InstructionValueProcedure colorOutgoingIncomingValues = new InstructionValueProcedure() {
 
             public Value doValue(LIRInstruction instruction, Value value, OperandMode mode, EnumSet<OperandFlag> flags) {
                 if (isVariable(value)) {

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanWalker.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanWalker.java
@@ -904,8 +904,9 @@ final class TraceLinearScanWalker extends TraceIntervalWalker {
                              * avoid errors
                              */
                             allocator.assignSpillSlot(interval);
-                            Debug.dump(allocator.getLIR(), description);
-                            allocator.printIntervals(description);
+                            if (Debug.isDumpEnabled()) {
+                                dumpLIRAndIntervals(description);
+                            }
                             throw new OutOfRegistersException("LinearScan: no register found", description);
                         }
 
@@ -937,6 +938,11 @@ final class TraceLinearScanWalker extends TraceIntervalWalker {
             splitAndSpillIntersectingIntervals(reg);
             return;
         }
+    }
+
+    protected void dumpLIRAndIntervals(String description) {
+        Debug.dump(allocator.getLIR(), description);
+        allocator.printIntervals(description);
     }
 
     @SuppressWarnings("try")

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/AllocationStage.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/AllocationStage.java
@@ -22,6 +22,7 @@
  */
 package com.oracle.graal.lir.phases;
 
+import static com.oracle.graal.compiler.common.BackendOptions.EnableSSIConstruction;
 import static com.oracle.graal.compiler.common.BackendOptions.UserOptions.TraceRA;
 
 import com.oracle.graal.compiler.common.GraalOptions;
@@ -31,12 +32,16 @@ import com.oracle.graal.lir.alloc.trace.TraceRegisterAllocationPhase;
 import com.oracle.graal.lir.dfa.LocationMarkerPhase;
 import com.oracle.graal.lir.dfa.MarkBasePointersPhase;
 import com.oracle.graal.lir.phases.AllocationPhase.AllocationContext;
+import com.oracle.graal.lir.ssi.SSIConstructionPhase;
 import com.oracle.graal.lir.stackslotalloc.LSStackSlotAllocator;
 import com.oracle.graal.lir.stackslotalloc.SimpleStackSlotAllocator;
 
 public class AllocationStage extends LIRPhaseSuite<AllocationContext> {
     public AllocationStage() {
         appendPhase(new MarkBasePointersPhase());
+        if (EnableSSIConstruction.getValue()) {
+            appendPhase(new SSIConstructionPhase());
+        }
         if (TraceRA.getValue()) {
             appendPhase(new TraceRegisterAllocationPhase());
         } else {

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/PreAllocationOptimizationStage.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/PreAllocationOptimizationStage.java
@@ -22,14 +22,12 @@
  */
 package com.oracle.graal.lir.phases;
 
-import static com.oracle.graal.compiler.common.BackendOptions.EnableSSIConstruction;
 import static com.oracle.graal.compiler.common.GraalOptions.SSA_LIR;
 
 import com.oracle.graal.compiler.common.BackendOptions;
 import com.oracle.graal.lir.constopt.ConstantLoadOptimization;
 import com.oracle.graal.lir.phases.PreAllocationOptimizationPhase.PreAllocationOptimizationContext;
 import com.oracle.graal.lir.ssa.SSADestructionPhase;
-import com.oracle.graal.lir.ssi.SSIConstructionPhase;
 
 public class PreAllocationOptimizationStage extends LIRPhaseSuite<PreAllocationOptimizationContext> {
     public PreAllocationOptimizationStage() {
@@ -38,9 +36,6 @@ public class PreAllocationOptimizationStage extends LIRPhaseSuite<PreAllocationO
         }
         if (ConstantLoadOptimization.Options.LIROptConstantLoadOptimization.getValue()) {
             appendPhase(new ConstantLoadOptimization());
-        }
-        if (EnableSSIConstruction.getValue()) {
-            appendPhase(new SSIConstructionPhase());
         }
     }
 }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIBlockValueMapImpl.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIBlockValueMapImpl.java
@@ -43,7 +43,7 @@ import com.oracle.graal.lir.LIRInstruction.OperandMode;
 import com.oracle.graal.lir.StandardOp.BlockEndOp;
 import com.oracle.graal.lir.StandardOp.LabelOp;
 import com.oracle.graal.lir.gen.BlockValueMap;
-import com.oracle.graal.lir.gen.LIRGeneratorTool;
+import com.oracle.graal.lir.gen.LIRGenerationResult;
 import com.oracle.graal.lir.util.ValueMap;
 import com.oracle.graal.lir.util.VariableVirtualStackValueMap;
 
@@ -237,36 +237,36 @@ public final class SSIBlockValueMapImpl implements BlockValueMap {
 
     // finish
 
-    public void finish(LIRGeneratorTool gen) {
-        Debug.dump(gen.getResult().getLIR(), "Before SSI operands");
-        AbstractControlFlowGraph<?> cfg = gen.getResult().getLIR().getControlFlowGraph();
+    public void finish(LIRGenerationResult lirGenRes) {
+        Debug.dump(lirGenRes.getLIR(), "Before SSI operands");
+        AbstractControlFlowGraph<?> cfg = lirGenRes.getLIR().getControlFlowGraph();
         for (AbstractBlockBase<?> block : cfg.getBlocks()) {
             // set label
             BlockData data = blockData.get(block);
             if (data != null) {
                 if (data.incoming != null && data.incoming.size() > 0) {
-                    LabelOp label = getLabel(gen, block);
+                    LabelOp label = getLabel(lirGenRes, block);
                     label.addIncomingValues(data.incoming.toArray(new Value[data.incoming.size()]));
                 }
                 // set block end
                 if (data.outgoing != null && data.outgoing.size() > 0) {
-                    BlockEndOp blockEndOp = getBlockEnd(gen, block);
+                    BlockEndOp blockEndOp = getBlockEnd(lirGenRes, block);
                     blockEndOp.addOutgoingValues(data.outgoing.toArray(new Value[data.outgoing.size()]));
                 }
             }
         }
     }
 
-    private static List<LIRInstruction> getLIRforBlock(LIRGeneratorTool gen, AbstractBlockBase<?> block) {
-        return gen.getResult().getLIR().getLIRforBlock(block);
+    private static List<LIRInstruction> getLIRforBlock(LIRGenerationResult lirGenRes, AbstractBlockBase<?> block) {
+        return lirGenRes.getLIR().getLIRforBlock(block);
     }
 
-    private static LabelOp getLabel(LIRGeneratorTool gen, AbstractBlockBase<?> block) {
-        return (LabelOp) getLIRforBlock(gen, block).get(0);
+    private static LabelOp getLabel(LIRGenerationResult lirGenRes, AbstractBlockBase<?> block) {
+        return (LabelOp) getLIRforBlock(lirGenRes, block).get(0);
     }
 
-    private static BlockEndOp getBlockEnd(LIRGeneratorTool gen, AbstractBlockBase<?> block) {
-        List<LIRInstruction> instructions = getLIRforBlock(gen, block);
+    private static BlockEndOp getBlockEnd(LIRGenerationResult lirGenRes, AbstractBlockBase<?> block) {
+        List<LIRInstruction> instructions = getLIRforBlock(lirGenRes, block);
         return (BlockEndOp) instructions.get(instructions.size() - 1);
     }
 }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIConstructionPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIConstructionPhase.java
@@ -39,7 +39,6 @@ import com.oracle.graal.lir.ValueConsumer;
 import com.oracle.graal.lir.framemap.FrameMapBuilder;
 import com.oracle.graal.lir.framemap.FrameMapBuilderTool;
 import com.oracle.graal.lir.gen.LIRGenerationResult;
-import com.oracle.graal.lir.gen.LIRGeneratorTool;
 import com.oracle.graal.lir.phases.PreAllocationOptimizationPhase;
 import com.oracle.graal.lir.ssa.SSAUtil;
 
@@ -48,10 +47,9 @@ public final class SSIConstructionPhase extends PreAllocationOptimizationPhase {
     @Override
     protected <B extends AbstractBlockBase<B>> void run(TargetDescription target, LIRGenerationResult lirGenRes, List<B> codeEmittingOrder, List<B> linearScanOrder,
                     PreAllocationOptimizationContext context) {
-        LIRGeneratorTool lirGen = context.lirGen;
         assert SSAUtil.verifySSAForm(lirGenRes.getLIR());
         LIR lir = lirGenRes.getLIR();
-        new SSIBuilder(lir, lirGenRes.getFrameMapBuilder()).build(lirGen);
+        new SSIBuilder(lir, lirGenRes.getFrameMapBuilder()).build(lirGenRes);
     }
 
     private static final class SSIBuilder {
@@ -66,7 +64,7 @@ public final class SSIConstructionPhase extends PreAllocationOptimizationPhase {
         }
 
         @SuppressWarnings("try")
-        private void build(LIRGeneratorTool lirGen) {
+        private void build(LIRGenerationResult lirGenRes) {
             Deque<AbstractBlockBase<?>> worklist = new ArrayDeque<>(lir.getControlFlowGraph().getBlocks());
             while (!worklist.isEmpty()) {
                 AbstractBlockBase<?> block = worklist.poll();
@@ -90,7 +88,7 @@ public final class SSIConstructionPhase extends PreAllocationOptimizationPhase {
                     }
                 }
             }
-            valueMap.finish(lirGen);
+            valueMap.finish(lirGenRes);
         }
 
         @SuppressWarnings("try")

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIConstructionPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIConstructionPhase.java
@@ -39,14 +39,14 @@ import com.oracle.graal.lir.ValueConsumer;
 import com.oracle.graal.lir.framemap.FrameMapBuilder;
 import com.oracle.graal.lir.framemap.FrameMapBuilderTool;
 import com.oracle.graal.lir.gen.LIRGenerationResult;
-import com.oracle.graal.lir.phases.PreAllocationOptimizationPhase;
+import com.oracle.graal.lir.phases.AllocationPhase;
 import com.oracle.graal.lir.ssa.SSAUtil;
 
-public final class SSIConstructionPhase extends PreAllocationOptimizationPhase {
+public final class SSIConstructionPhase extends AllocationPhase {
 
     @Override
     protected <B extends AbstractBlockBase<B>> void run(TargetDescription target, LIRGenerationResult lirGenRes, List<B> codeEmittingOrder, List<B> linearScanOrder,
-                    PreAllocationOptimizationContext context) {
+                    AllocationContext context) {
         assert SSAUtil.verifySSAForm(lirGenRes.getLIR());
         LIR lir = lirGenRes.getLIR();
         new SSIBuilder(lir, lirGenRes.getFrameMapBuilder()).build(lirGenRes);


### PR DESCRIPTION
Currently mark base pointer phase is executed after SSI construction which increases runtime due to the increased number of operands. This change moves SSI construction after the marking phase to avoid this.
It also contains other minor clean-ups of debug code, options and visitor calls.