### PR TITLE
Introduce CheckedJavaType to avoid recomputing assumptions

### DIFF
--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/type/CheckedJavaType.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/type/CheckedJavaType.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package com.oracle.graal.compiler.common.type;
 
 import jdk.vm.ci.meta.Assumptions;

--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/type/CheckedJavaType.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/type/CheckedJavaType.java
@@ -1,6 +1,7 @@
 package com.oracle.graal.compiler.common.type;
 
 import jdk.vm.ci.meta.Assumptions;
+import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaType;
 
 public final class CheckedJavaType {
@@ -27,11 +28,26 @@ public final class CheckedJavaType {
         return new CheckedJavaType(exactType, true);
     }
 
+    /**
+     * Returns the underlying {@link ResolvedJavaType} object.
+     */
     public ResolvedJavaType getType() {
         return type;
     }
 
-    public boolean isExactType() {
+    /**
+     * Returns the name of this type in internal form.
+     *
+     * See {@link JavaType#getName()}.
+     */
+    public String getName() {
+        return getType().getName();
+    }
+
+    /**
+     * Returns {@code true} if and only if this type is the only leaf type.
+     */
+    public boolean isExact() {
         return exactType;
     }
 

--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/type/CheckedJavaType.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/type/CheckedJavaType.java
@@ -1,0 +1,38 @@
+package com.oracle.graal.compiler.common.type;
+
+import jdk.vm.ci.meta.Assumptions;
+import jdk.vm.ci.meta.ResolvedJavaType;
+
+public final class CheckedJavaType {
+    private final ResolvedJavaType type;
+    private final boolean exactType;
+
+    private CheckedJavaType(ResolvedJavaType type, boolean exactType) {
+        this.type = type;
+        this.exactType = exactType;
+    }
+
+    public static CheckedJavaType create(Assumptions assumptions, ResolvedJavaType type) {
+        ResolvedJavaType exactType = type.asExactType();
+        if (exactType == null) {
+            Assumptions.AssumptionResult<ResolvedJavaType> leafConcreteSubtype = type.findLeafConcreteSubtype();
+            if (leafConcreteSubtype != null && leafConcreteSubtype.canRecordTo(assumptions)) {
+                leafConcreteSubtype.recordTo(assumptions);
+                exactType = leafConcreteSubtype.getResult();
+            }
+        }
+        if (exactType == null) {
+            return new CheckedJavaType(type, false);
+        }
+        return new CheckedJavaType(exactType, true);
+    }
+
+    public ResolvedJavaType getType() {
+        return type;
+    }
+
+    public boolean isExactType() {
+        return exactType;
+    }
+
+}

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/meta/HotSpotGraphBuilderPlugins.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/meta/HotSpotGraphBuilderPlugins.java
@@ -178,7 +178,7 @@ public class HotSpotGraphBuilderPlugins {
         r.register2("cast", Receiver.class, Object.class, new InvocationPlugin() {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode object) {
                 ValueNode javaClass = receiver.get();
-                ValueNode folded = ClassCastNode.tryFold(GraphUtil.originalValue(javaClass), object, b.getConstantReflection(), b.getAssumptions());
+                ValueNode folded = ClassCastNode.tryFold(GraphUtil.originalValue(javaClass), object, b.getConstantReflection());
                 if (folded != null) {
                     b.addPush(JavaKind.Object, folded);
                 } else {

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/nodes/ClassCastNode.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/nodes/ClassCastNode.java
@@ -22,12 +22,12 @@
  */
 package com.oracle.graal.hotspot.nodes;
 
-import jdk.vm.ci.meta.Assumptions;
 import jdk.vm.ci.meta.ConstantReflectionProvider;
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.Canonicalizable;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
@@ -68,15 +68,15 @@ public final class ClassCastNode extends MacroStateSplitNode implements Canonica
 
     @Override
     public ValueNode canonical(CanonicalizerTool tool, ValueNode forJavaClass, ValueNode forObject) {
-        ValueNode folded = tryFold(forJavaClass, forObject, tool.getConstantReflection(), null);
+        ValueNode folded = tryFold(forJavaClass, forObject, tool.getConstantReflection());
         return folded != null ? folded : this;
     }
 
-    public static ValueNode tryFold(ValueNode javaClass, ValueNode object, ConstantReflectionProvider constantReflection, Assumptions assumptions) {
+    public static ValueNode tryFold(ValueNode javaClass, ValueNode object, ConstantReflectionProvider constantReflection) {
         if (javaClass != null && javaClass.isConstant()) {
             ResolvedJavaType type = constantReflection.asJavaType(javaClass.asConstant());
             if (type != null && !type.isPrimitive()) {
-                return CheckCastNode.create(type, object, null, false, assumptions);
+                return CheckCastNode.create(CheckedJavaType.create(javaClass.graph().getAssumptions(), type), object, null, false);
             }
         }
         return null;

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/replacements/InstanceOfSnippets.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/replacements/InstanceOfSnippets.java
@@ -249,8 +249,8 @@ public class InstanceOfSnippets implements Snippets {
                 InstanceOfNode instanceOf = (InstanceOfNode) replacer.instanceOf;
                 ValueNode object = instanceOf.getValue();
                 Assumptions assumptions = instanceOf.graph().getAssumptions();
-                TypeCheckHints hintInfo = new TypeCheckHints(instanceOf.type(), instanceOf.profile(), assumptions, TypeCheckMinProfileHitProbability.getValue(), TypeCheckMaxHints.getValue());
-                final HotSpotResolvedObjectType type = (HotSpotResolvedObjectType) instanceOf.type();
+                TypeCheckHints hintInfo = new TypeCheckHints(instanceOf.type().getType(), instanceOf.profile(), assumptions, TypeCheckMinProfileHitProbability.getValue(), TypeCheckMaxHints.getValue());
+                final HotSpotResolvedObjectType type = (HotSpotResolvedObjectType) instanceOf.type().getType();
                 ConstantNode hub = ConstantNode.forConstant(KlassPointerStamp.klassNonNull(), type.klass(), providers.getMetaAccess(), instanceOf.graph());
 
                 Arguments args;

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -2929,7 +2929,7 @@ public class BytecodeParser implements GraphBuilderContext {
     }
 
     private JavaTypeProfile getProfileForTypeCheck(CheckedJavaType type) {
-        if (parsingIntrinsic() || profilingInfo == null || !optimisticOpts.useTypeCheckHints() || type.isExactType()) {
+        if (parsingIntrinsic() || profilingInfo == null || !optimisticOpts.useTypeCheckHints() || type.isExact()) {
             return null;
         } else {
             return profilingInfo.getTypeProfile(bci());

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -256,6 +256,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import jdk.vm.ci.code.BailoutException;
 import jdk.vm.ci.code.BytecodeFrame;
 import jdk.vm.ci.code.BytecodePosition;
@@ -1125,11 +1126,11 @@ public class BytecodeParser implements GraphBuilderContext {
         lastInstr.setNext(handleException(nonNullException, bci()));
     }
 
-    protected ValueNode createCheckCast(ResolvedJavaType type, ValueNode object, JavaTypeProfile profileForTypeCheck, boolean forStoreCheck) {
-        return CheckCastNode.create(type, object, profileForTypeCheck, forStoreCheck, graph.getAssumptions());
+    protected ValueNode createCheckCast(CheckedJavaType type, ValueNode object, JavaTypeProfile profileForTypeCheck, boolean forStoreCheck) {
+        return CheckCastNode.create(type, object, profileForTypeCheck, forStoreCheck);
     }
 
-    protected ValueNode createInstanceOf(ResolvedJavaType type, ValueNode object, JavaTypeProfile profileForTypeCheck) {
+    protected ValueNode createInstanceOf(CheckedJavaType type, ValueNode object, JavaTypeProfile profileForTypeCheck) {
         return InstanceOfNode.create(type, object, profileForTypeCheck);
     }
 
@@ -2167,25 +2168,25 @@ public class BytecodeParser implements GraphBuilderContext {
         if (graphBuilderConfig.eagerResolving()) {
             catchType = lookupType(block.handler.catchTypeCPI(), INSTANCEOF);
         }
-        boolean initialized = (catchType instanceof ResolvedJavaType);
-        if (initialized && graphBuilderConfig.getSkippedExceptionTypes() != null) {
-            ResolvedJavaType resolvedCatchType = (ResolvedJavaType) catchType;
-            for (ResolvedJavaType skippedType : graphBuilderConfig.getSkippedExceptionTypes()) {
-                if (skippedType.isAssignableFrom(resolvedCatchType)) {
-                    BciBlock nextBlock = block.getSuccessorCount() == 1 ? blockMap.getUnwindBlock() : block.getSuccessor(1);
-                    ValueNode exception = frameState.stack[0];
-                    FixedNode trueSuccessor = graph.add(new DeoptimizeNode(InvalidateReprofile, UnreachedCode));
-                    FixedNode nextDispatch = createTarget(nextBlock, frameState);
-                    append(new IfNode(graph.unique(InstanceOfNode.create((ResolvedJavaType) catchType, exception, null)), trueSuccessor, nextDispatch, 0));
-                    return;
+        if (catchType instanceof ResolvedJavaType) {
+            CheckedJavaType checkedCatchType = CheckedJavaType.create(graph.getAssumptions(), (ResolvedJavaType) catchType);
+
+            if (graphBuilderConfig.getSkippedExceptionTypes() != null) {
+                for (ResolvedJavaType skippedType : graphBuilderConfig.getSkippedExceptionTypes()) {
+                    if (skippedType.isAssignableFrom(checkedCatchType.getType())) {
+                        BciBlock nextBlock = block.getSuccessorCount() == 1 ? blockMap.getUnwindBlock() : block.getSuccessor(1);
+                        ValueNode exception = frameState.stack[0];
+                        FixedNode trueSuccessor = graph.add(new DeoptimizeNode(InvalidateReprofile, UnreachedCode));
+                        FixedNode nextDispatch = createTarget(nextBlock, frameState);
+                        append(new IfNode(graph.unique(InstanceOfNode.create(checkedCatchType, exception, null)), trueSuccessor, nextDispatch, 0));
+                        return;
+                    }
                 }
             }
-        }
 
-        if (initialized) {
             BciBlock nextBlock = block.getSuccessorCount() == 1 ? blockMap.getUnwindBlock() : block.getSuccessor(1);
             ValueNode exception = frameState.stack[0];
-            CheckCastNode checkCast = graph.add(new CheckCastNode((ResolvedJavaType) catchType, exception, null, false));
+            CheckCastNode checkCast = graph.add(new CheckCastNode(checkedCatchType, exception, null, false));
             frameState.pop(JavaKind.Object);
             frameState.push(JavaKind.Object, checkCast);
             FixedNode catchSuccessor = createTarget(block.getSuccessor(0), frameState);
@@ -2193,7 +2194,7 @@ public class BytecodeParser implements GraphBuilderContext {
             frameState.push(JavaKind.Object, exception);
             FixedNode nextDispatch = createTarget(nextBlock, frameState);
             checkCast.setNext(catchSuccessor);
-            append(new IfNode(graph.unique(InstanceOfNode.create((ResolvedJavaType) catchType, exception, null)), checkCast, nextDispatch, 0.5));
+            append(new IfNode(graph.unique(InstanceOfNode.create(checkedCatchType, exception, null)), checkCast, nextDispatch, 0.5));
         } else {
             handleUnresolvedExceptionType(catchType);
         }
@@ -2927,8 +2928,8 @@ public class BytecodeParser implements GraphBuilderContext {
         }
     }
 
-    private JavaTypeProfile getProfileForTypeCheck(ResolvedJavaType type) {
-        if (parsingIntrinsic() || profilingInfo == null || !optimisticOpts.useTypeCheckHints() || type.isLeaf()) {
+    private JavaTypeProfile getProfileForTypeCheck(CheckedJavaType type) {
+        if (parsingIntrinsic() || profilingInfo == null || !optimisticOpts.useTypeCheckHints() || type.isExactType()) {
             return null;
         } else {
             return profilingInfo.getTypeProfile(bci());
@@ -2944,24 +2945,24 @@ public class BytecodeParser implements GraphBuilderContext {
             handleUnresolvedCheckCast(type, object);
             return;
         }
-        ResolvedJavaType resolvedType = (ResolvedJavaType) type;
-        JavaTypeProfile profile = getProfileForTypeCheck(resolvedType);
+        CheckedJavaType checkedType = CheckedJavaType.create(graph.getAssumptions(), (ResolvedJavaType) type);
+        JavaTypeProfile profile = getProfileForTypeCheck(checkedType);
 
         for (NodePlugin plugin : graphBuilderConfig.getPlugins().getNodePlugins()) {
-            if (plugin.handleCheckCast(this, object, resolvedType, profile)) {
+            if (plugin.handleCheckCast(this, object, checkedType.getType(), profile)) {
                 return;
             }
         }
 
         ValueNode checkCastNode = null;
         if (profile != null) {
-            if (CheckCastNode.findSynonym(resolvedType, object) == object) {
+            if (CheckCastNode.findSynonym(checkedType, object) == object) {
                 // Don't insert a profiled type check if the checkcast would simply go away
                 checkCastNode = object;
             } else if (profile.getNullSeen().isFalse()) {
                 object = appendNullCheck(object);
                 ResolvedJavaType singleType = profile.asSingleType();
-                if (singleType != null && resolvedType.isAssignableFrom(singleType)) {
+                if (singleType != null && checkedType.getType().isAssignableFrom(singleType)) {
                     LogicNode typeCheck = append(TypeCheckNode.create(singleType, object));
                     if (typeCheck.isTautology()) {
                         checkCastNode = object;
@@ -2973,7 +2974,7 @@ public class BytecodeParser implements GraphBuilderContext {
             }
         }
         if (checkCastNode == null) {
-            checkCastNode = append(createCheckCast(resolvedType, object, profile, false));
+            checkCastNode = append(createCheckCast(checkedType, object, profile, false));
         }
         frameState.push(JavaKind.Object, checkCastNode);
     }
@@ -3000,11 +3001,11 @@ public class BytecodeParser implements GraphBuilderContext {
             handleUnresolvedInstanceOf(type, object);
             return;
         }
-        ResolvedJavaType resolvedType = (ResolvedJavaType) type;
+        CheckedJavaType resolvedType = CheckedJavaType.create(graph.getAssumptions(), (ResolvedJavaType) type);
         JavaTypeProfile profile = getProfileForTypeCheck(resolvedType);
 
         for (NodePlugin plugin : graphBuilderConfig.getPlugins().getNodePlugins()) {
-            if (plugin.handleInstanceOf(this, object, resolvedType, profile)) {
+            if (plugin.handleInstanceOf(this, object, resolvedType.getType(), profile)) {
                 return;
             }
         }
@@ -3019,7 +3020,7 @@ public class BytecodeParser implements GraphBuilderContext {
                     if (!typeCheck.isTautology()) {
                         append(new FixedGuardNode(typeCheck, DeoptimizationReason.TypeCheckedInliningViolated, DeoptimizationAction.InvalidateReprofile));
                     }
-                    instanceOfNode = LogicConstantNode.forBoolean(resolvedType.isAssignableFrom(singleType));
+                    instanceOfNode = LogicConstantNode.forBoolean(resolvedType.getType().isAssignableFrom(singleType));
                 }
             }
         }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/IfNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/IfNode.java
@@ -467,8 +467,8 @@ public final class IfNode extends ControlSplitNode implements Simplifiable, LIRL
                 }
             } else if (b instanceof InstanceOfNode) {
                 InstanceOfNode instanceOfB = (InstanceOfNode) b;
-                if (instanceOfA.getValue() == instanceOfB.getValue() && !instanceOfA.type().isInterface() && !instanceOfB.type().isInterface() &&
-                                !instanceOfA.type().isAssignableFrom(instanceOfB.type()) && !instanceOfB.type().isAssignableFrom(instanceOfA.type())) {
+                if (instanceOfA.getValue() == instanceOfB.getValue() && !instanceOfA.type().getType().isInterface() && !instanceOfB.type().getType().isInterface() &&
+                                !instanceOfA.type().getType().isAssignableFrom(instanceOfB.type().getType()) && !instanceOfB.type().getType().isAssignableFrom(instanceOfA.type().getType())) {
                     // Two instanceof on the same value with mutually exclusive types.
                     Debug.log("Can swap instanceof for types %s and %s", instanceOfA.type(), instanceOfB.type());
                     swapInstanceOfProfiles(probabilityA, probabilityB, instanceOfA, instanceOfB);
@@ -566,7 +566,7 @@ public final class IfNode extends ControlSplitNode implements Simplifiable, LIRL
                 for (ProfiledType profiledType : profileA.getTypes()) {
                     newProfiledTypesB.add(new MutableProfiledType(profiledType.getType(), profiledType.getProbability()));
                     totalProbabilityB += profiledType.getProbability();
-                    if (!instanceOfB.type().isAssignableFrom(profiledType.getType())) {
+                    if (!instanceOfB.type().getType().isAssignableFrom(profiledType.getType())) {
                         double typeProbabilityA = profiledType.getProbability() / (1 - probabilityB);
                         newProfiledTypesA.add(new MutableProfiledType(profiledType.getType(), typeProbabilityA));
                         totalProbabilityA += typeProbabilityA;
@@ -583,7 +583,7 @@ public final class IfNode extends ControlSplitNode implements Simplifiable, LIRL
                     double typeProbabilityB = profiledType.getProbability() * (1 - probabilityA);
                     appendOrMerge(profiledType.getType(), typeProbabilityB, searchB, newProfiledTypesB);
                     totalProbabilityB += typeProbabilityB;
-                    if (!instanceOfB.type().isAssignableFrom(profiledType.getType())) {
+                    if (!instanceOfB.type().getType().isAssignableFrom(profiledType.getType())) {
                         double typeProbabilityA = typeProbabilityB / (1 - probabilityB);
                         appendOrMerge(profiledType.getType(), typeProbabilityA, searchA, newProfiledTypesA);
                         totalProbabilityA += typeProbabilityA;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/CheckCastDynamicNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/CheckCastDynamicNode.java
@@ -24,6 +24,7 @@ package com.oracle.graal.nodes.java;
 
 import jdk.vm.ci.meta.ResolvedJavaType;
 
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.Canonicalizable;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
@@ -99,7 +100,7 @@ public final class CheckCastDynamicNode extends FixedWithNextNode implements Can
         if (forHub.isConstant()) {
             ResolvedJavaType t = tool.getConstantReflection().asJavaType(forHub.asConstant());
             if (t != null) {
-                return new CheckCastNode(t, forObject, null, forStoreCheck);
+                return new CheckCastNode(CheckedJavaType.create(graph().getAssumptions(), t), forObject, null, forStoreCheck);
             }
         }
         return this;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/CheckCastNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/CheckCastNode.java
@@ -22,18 +22,7 @@
  */
 package com.oracle.graal.nodes.java;
 
-import static com.oracle.graal.nodes.extended.BranchProbabilityNode.NOT_FREQUENT_PROBABILITY;
-import static jdk.vm.ci.meta.DeoptimizationAction.InvalidateReprofile;
-import static jdk.vm.ci.meta.DeoptimizationReason.ArrayStoreException;
-import static jdk.vm.ci.meta.DeoptimizationReason.ClassCastException;
-import static jdk.vm.ci.meta.DeoptimizationReason.UnreachedCode;
-
 import com.oracle.graal.compiler.common.type.CheckedJavaType;
-import jdk.vm.ci.meta.JavaConstant;
-import jdk.vm.ci.meta.JavaTypeProfile;
-import jdk.vm.ci.meta.ResolvedJavaType;
-import jdk.vm.ci.meta.TriState;
-
 import com.oracle.graal.compiler.common.type.ObjectStamp;
 import com.oracle.graal.compiler.common.type.Stamp;
 import com.oracle.graal.compiler.common.type.StampFactory;
@@ -58,6 +47,16 @@ import com.oracle.graal.nodes.spi.ValueProxy;
 import com.oracle.graal.nodes.spi.Virtualizable;
 import com.oracle.graal.nodes.spi.VirtualizerTool;
 import com.oracle.graal.nodes.type.StampTool;
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaTypeProfile;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import jdk.vm.ci.meta.TriState;
+
+import static com.oracle.graal.nodes.extended.BranchProbabilityNode.NOT_FREQUENT_PROBABILITY;
+import static jdk.vm.ci.meta.DeoptimizationAction.InvalidateReprofile;
+import static jdk.vm.ci.meta.DeoptimizationReason.ArrayStoreException;
+import static jdk.vm.ci.meta.DeoptimizationReason.ClassCastException;
+import static jdk.vm.ci.meta.DeoptimizationReason.UnreachedCode;
 
 /**
  * Implements a type check against a compile-time known type.
@@ -81,7 +80,7 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
     }
 
     protected CheckCastNode(NodeClass<? extends CheckCastNode> c, CheckedJavaType type, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck) {
-        super(c, StampFactory.declaredTrusted(type.getType()).improveWith(object.stamp()));
+        super(c, (type != null) ? StampFactory.declaredTrusted(type.getType()).improveWith(object.stamp()) : null);
         assert object.stamp() instanceof ObjectStamp : object;
         assert type != null;
         this.type = type;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/CheckCastNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/CheckCastNode.java
@@ -27,8 +27,8 @@ import static jdk.vm.ci.meta.DeoptimizationAction.InvalidateReprofile;
 import static jdk.vm.ci.meta.DeoptimizationReason.ArrayStoreException;
 import static jdk.vm.ci.meta.DeoptimizationReason.ClassCastException;
 import static jdk.vm.ci.meta.DeoptimizationReason.UnreachedCode;
-import jdk.vm.ci.meta.Assumptions;
-import jdk.vm.ci.meta.Assumptions.AssumptionResult;
+
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaTypeProfile;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -67,7 +67,7 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
 
     public static final NodeClass<CheckCastNode> TYPE = NodeClass.create(CheckCastNode.class);
     @Input protected ValueNode object;
-    protected final ResolvedJavaType type;
+    protected final CheckedJavaType type;
     protected final JavaTypeProfile profile;
 
     /**
@@ -76,12 +76,12 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
      */
     protected final boolean forStoreCheck;
 
-    public CheckCastNode(ResolvedJavaType type, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck) {
+    public CheckCastNode(CheckedJavaType type, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck) {
         this(TYPE, type, object, profile, forStoreCheck);
     }
 
-    protected CheckCastNode(NodeClass<? extends CheckCastNode> c, ResolvedJavaType type, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck) {
-        super(c, StampFactory.declaredTrusted(type).improveWith(object.stamp()));
+    protected CheckCastNode(NodeClass<? extends CheckCastNode> c, CheckedJavaType type, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck) {
+        super(c, StampFactory.declaredTrusted(type.getType()).improveWith(object.stamp()));
         assert object.stamp() instanceof ObjectStamp : object;
         assert type != null;
         this.type = type;
@@ -90,18 +90,12 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
         this.forStoreCheck = forStoreCheck;
     }
 
-    public static ValueNode create(ResolvedJavaType inputType, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck, Assumptions assumptions) {
-        ResolvedJavaType type = inputType;
+    public static ValueNode create(CheckedJavaType type, ValueNode object, JavaTypeProfile profile, boolean forStoreCheck) {
         ValueNode synonym = findSynonym(type, object);
         if (synonym != null) {
             return synonym;
         }
         assert object.stamp() instanceof ObjectStamp : object;
-        AssumptionResult<ResolvedJavaType> leafConcreteSubtype = type.findLeafConcreteSubtype();
-        if (leafConcreteSubtype != null && leafConcreteSubtype.canRecordTo(assumptions) && !leafConcreteSubtype.getResult().equals(type)) {
-            leafConcreteSubtype.recordTo(assumptions);
-            type = leafConcreteSubtype.getResult();
-        }
         return new CheckCastNode(type, object, profile, forStoreCheck);
     }
 
@@ -137,14 +131,14 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
      */
     @Override
     public void lower(LoweringTool tool) {
-        Stamp newStamp = StampFactory.declaredTrusted(type).improveWith(object().stamp());
+        Stamp newStamp = StampFactory.declaredTrusted(type.getType()).improveWith(object().stamp());
         LogicNode condition;
         LogicNode innerNode = null;
         ValueNode theValue = object;
         if (newStamp.isEmpty()) {
             // This is a check cast that will always fail
             condition = LogicConstantNode.contradiction(graph());
-            newStamp = StampFactory.declaredTrusted(type);
+            newStamp = StampFactory.declaredTrusted(type.getType());
         } else if (StampTool.isPointerNonNull(object)) {
             condition = graph().addWithoutUnique(InstanceOfNode.create(type, object, profile));
             innerNode = condition;
@@ -186,7 +180,7 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
     @Override
     public boolean inferStamp() {
         if (object().stamp() instanceof ObjectStamp) {
-            ObjectStamp castStamp = (ObjectStamp) StampFactory.declaredTrusted(type);
+            ObjectStamp castStamp = (ObjectStamp) StampFactory.declaredTrusted(type.getType());
             return updateStamp(castStamp.improveWith(object().stamp()));
         }
         return false;
@@ -198,22 +192,12 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
         if (synonym != null) {
             return synonym;
         }
-
-        AssumptionResult<ResolvedJavaType> leafConcreteSubtype = type.findLeafConcreteSubtype();
-        Assumptions assumptions = graph().getAssumptions();
-        if (leafConcreteSubtype != null && leafConcreteSubtype.canRecordTo(assumptions) && !leafConcreteSubtype.getResult().equals(type)) {
-            // Propagate more precise type information to usages of the checkcast.
-            leafConcreteSubtype.recordTo(assumptions);
-            CheckCastNode result = new CheckCastNode(leafConcreteSubtype.getResult(), object, profile, forStoreCheck);
-            return result;
-        }
-
         return this;
     }
 
-    public static ValueNode findSynonym(ResolvedJavaType type, ValueNode object) {
+    public static ValueNode findSynonym(CheckedJavaType type, ValueNode object) {
         ResolvedJavaType objectType = StampTool.typeOrNull(object);
-        if (objectType != null && type.isAssignableFrom(objectType)) {
+        if (objectType != null && type.getType().isAssignableFrom(objectType)) {
             // we don't have to check for null types here because they will also pass the
             // checkcast.
             return object;
@@ -232,7 +216,7 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
     /**
      * Gets the type being cast to.
      */
-    public ResolvedJavaType type() {
+    public CheckedJavaType type() {
         return type;
     }
 
@@ -257,7 +241,7 @@ public class CheckCastNode extends FixedWithNextNode implements Canonicalizable,
         if (testStamp instanceof ObjectStamp) {
             ObjectStamp objectStamp = (ObjectStamp) testStamp;
             ResolvedJavaType objectType = objectStamp.type();
-            if (objectType != null && type.isAssignableFrom(objectType)) {
+            if (objectType != null && type.getType().isAssignableFrom(objectType)) {
                 return TriState.TRUE;
             } else if (objectStamp.alwaysNull()) {
                 return TriState.TRUE;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfDynamicNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfDynamicNode.java
@@ -22,19 +22,22 @@
  */
 package com.oracle.graal.nodes.java;
 
-import jdk.vm.ci.meta.ConstantReflectionProvider;
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.ResolvedJavaType;
-
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
+import com.oracle.graal.graph.Graph;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.Canonicalizable;
 import com.oracle.graal.graph.spi.CanonicalizerTool;
 import com.oracle.graal.nodeinfo.NodeInfo;
 import com.oracle.graal.nodes.LogicConstantNode;
 import com.oracle.graal.nodes.LogicNode;
+import com.oracle.graal.nodes.StructuredGraph;
 import com.oracle.graal.nodes.ValueNode;
 import com.oracle.graal.nodes.spi.Lowerable;
 import com.oracle.graal.nodes.spi.LoweringTool;
+import jdk.vm.ci.meta.Assumptions;
+import jdk.vm.ci.meta.ConstantReflectionProvider;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.ResolvedJavaType;
 
 /**
  * The {@code InstanceOfDynamicNode} represents a type check where the type being checked is not
@@ -48,8 +51,8 @@ public class InstanceOfDynamicNode extends LogicNode implements Canonicalizable.
     @Input ValueNode object;
     @Input ValueNode mirror;
 
-    public static LogicNode create(ConstantReflectionProvider constantReflection, ValueNode mirror, ValueNode object) {
-        LogicNode synonym = findSynonym(constantReflection, object, mirror);
+    public static LogicNode create(Assumptions assumptions, ConstantReflectionProvider constantReflection, ValueNode mirror, ValueNode object) {
+        LogicNode synonym = findSynonym(assumptions, constantReflection, object, mirror);
         if (synonym != null) {
             return synonym;
         }
@@ -69,14 +72,14 @@ public class InstanceOfDynamicNode extends LogicNode implements Canonicalizable.
         tool.getLowerer().lower(this, tool);
     }
 
-    private static LogicNode findSynonym(ConstantReflectionProvider constantReflection, ValueNode forObject, ValueNode forMirror) {
+    private static LogicNode findSynonym(Assumptions assumptions, ConstantReflectionProvider constantReflection, ValueNode forObject, ValueNode forMirror) {
         if (forMirror.isConstant()) {
             ResolvedJavaType t = constantReflection.asJavaType(forMirror.asConstant());
             if (t != null) {
                 if (t.isPrimitive()) {
                     return LogicConstantNode.contradiction();
                 } else {
-                    return InstanceOfNode.create(t, forObject, null);
+                    return InstanceOfNode.create(CheckedJavaType.create(assumptions, t), forObject, null);
                 }
             }
         }
@@ -84,7 +87,11 @@ public class InstanceOfDynamicNode extends LogicNode implements Canonicalizable.
     }
 
     public LogicNode canonical(CanonicalizerTool tool, ValueNode forObject, ValueNode forMirror) {
-        LogicNode res = findSynonym(tool.getConstantReflection(), forObject, forMirror);
+        StructuredGraph graph = forObject.graph();
+        if (graph == null) {
+            graph = forMirror.graph();
+        }
+        LogicNode res = findSynonym(graph.getAssumptions(), tool.getConstantReflection(), forObject, forMirror);
         if (res == null) {
             res = this;
         }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfDynamicNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfDynamicNode.java
@@ -23,7 +23,6 @@
 package com.oracle.graal.nodes.java;
 
 import com.oracle.graal.compiler.common.type.CheckedJavaType;
-import com.oracle.graal.graph.Graph;
 import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.spi.Canonicalizable;
 import com.oracle.graal.graph.spi.CanonicalizerTool;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfNode.java
@@ -145,7 +145,7 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
                 return LogicConstantNode.contradiction();
             } else {
                 boolean superType = inputType.isAssignableFrom(type.getType());
-                if (!superType && (type.isExactType() || (!isInterfaceOrArrayOfInterface(inputType) && !isInterfaceOrArrayOfInterface(type.getType())))) {
+                if (!superType && (type.isExact() || (!isInterfaceOrArrayOfInterface(inputType) && !isInterfaceOrArrayOfInterface(type.getType())))) {
                     return LogicConstantNode.contradiction();
                 }
                 // since the subtype comparison was only performed on a declared type we don't
@@ -153,7 +153,7 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
             }
         }
 
-        if (type.isExactType() && nonNull) {
+        if (type.isExact() && nonNull) {
             return TypeCheckNode.create(type.getType(), object);
         }
         return null;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/InstanceOfNode.java
@@ -28,6 +28,7 @@ import jdk.vm.ci.meta.JavaTypeProfile;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.TriState;
 
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import com.oracle.graal.compiler.common.type.ObjectStamp;
 import com.oracle.graal.compiler.common.type.Stamp;
 import com.oracle.graal.compiler.common.type.StampFactory;
@@ -52,21 +53,21 @@ import com.oracle.graal.nodes.spi.VirtualizerTool;
 public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtualizable {
     public static final NodeClass<InstanceOfNode> TYPE = NodeClass.create(InstanceOfNode.class);
 
-    protected final ResolvedJavaType type;
+    protected final CheckedJavaType type;
     protected JavaTypeProfile profile;
 
-    private InstanceOfNode(ResolvedJavaType type, ValueNode object, JavaTypeProfile profile) {
+    private InstanceOfNode(CheckedJavaType type, ValueNode object, JavaTypeProfile profile) {
         this(TYPE, type, object, profile);
     }
 
-    protected InstanceOfNode(NodeClass<? extends InstanceOfNode> c, ResolvedJavaType type, ValueNode object, JavaTypeProfile profile) {
+    protected InstanceOfNode(NodeClass<? extends InstanceOfNode> c, CheckedJavaType type, ValueNode object, JavaTypeProfile profile) {
         super(c, object);
         this.type = type;
         this.profile = profile;
         assert type != null;
     }
 
-    public static LogicNode create(ResolvedJavaType type, ValueNode object, JavaTypeProfile profile) {
+    public static LogicNode create(CheckedJavaType type, ValueNode object, JavaTypeProfile profile) {
         ObjectStamp objectStamp = (ObjectStamp) object.stamp();
         LogicNode constantValue = findSynonym(object, type, objectStamp.type(), objectStamp.nonNull(), objectStamp.isExactType());
         if (constantValue != null) {
@@ -116,7 +117,7 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
         if (result != null) {
             return result;
         }
-        if (type().isAssignableFrom(inputType)) {
+        if (type().getType().isAssignableFrom(inputType)) {
             if (!nonNull) {
                 // the instanceof matches if the object is non-null, so return true
                 // depending on the null-ness.
@@ -126,11 +127,11 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
         return null;
     }
 
-    public static LogicNode findSynonym(ValueNode object, ResolvedJavaType type, ResolvedJavaType inputType, boolean nonNull, boolean exactType) {
+    public static LogicNode findSynonym(ValueNode object, CheckedJavaType type, ResolvedJavaType inputType, boolean nonNull, boolean exactType) {
         if (inputType == null) {
             return null;
         }
-        boolean subType = type.isAssignableFrom(inputType);
+        boolean subType = type.getType().isAssignableFrom(inputType);
         if (subType) {
             if (nonNull) {
                 // the instanceOf matches, so return true
@@ -143,8 +144,8 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
                 // also make the check fail.
                 return LogicConstantNode.contradiction();
             } else {
-                boolean superType = inputType.isAssignableFrom(type);
-                if (!superType && (type.asExactType() != null || (!isInterfaceOrArrayOfInterface(inputType) && !isInterfaceOrArrayOfInterface(type)))) {
+                boolean superType = inputType.isAssignableFrom(type.getType());
+                if (!superType && (type.isExactType() || (!isInterfaceOrArrayOfInterface(inputType) && !isInterfaceOrArrayOfInterface(type.getType())))) {
                     return LogicConstantNode.contradiction();
                 }
                 // since the subtype comparison was only performed on a declared type we don't
@@ -152,8 +153,8 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
             }
         }
 
-        if (type.isLeaf() && nonNull) {
-            return TypeCheckNode.create(type, object);
+        if (type.isExactType() && nonNull) {
+            return TypeCheckNode.create(type.getType(), object);
         }
         return null;
     }
@@ -161,7 +162,7 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
     /**
      * Gets the type being tested.
      */
-    public ResolvedJavaType type() {
+    public CheckedJavaType type() {
         return type;
     }
 
@@ -187,7 +188,7 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
         if (negated) {
             return null;
         } else {
-            return StampFactory.declaredTrustedNonNull(type);
+            return StampFactory.declaredTrustedNonNull(type.getType());
         }
     }
 
@@ -201,7 +202,7 @@ public class InstanceOfNode extends UnaryOpLogicNode implements Lowerable, Virtu
 
             ResolvedJavaType objectType = objectStamp.type();
             if (objectType != null) {
-                ResolvedJavaType instanceofType = type;
+                ResolvedJavaType instanceofType = type.getType();
                 if (instanceofType.isAssignableFrom(objectType)) {
                     if (objectStamp.nonNull()) {
                         return TriState.TRUE;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/MethodCallTargetNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/MethodCallTargetNode.java
@@ -22,6 +22,7 @@
  */
 package com.oracle.graal.nodes.java;
 
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import jdk.vm.ci.code.BytecodeFrame;
 import jdk.vm.ci.meta.Assumptions;
 import jdk.vm.ci.meta.Assumptions.AssumptionResult;
@@ -236,7 +237,7 @@ public class MethodCallTargetNode extends CallTargetNode implements IterableNode
                  * an assumption but as we need an instanceof check anyway we can verify both
                  * properties by checking of the receiver is an instance of the single implementor.
                  */
-                LogicNode condition = graph().unique(InstanceOfNode.create(singleImplementor, receiver, getProfile()));
+                LogicNode condition = graph().unique(InstanceOfNode.create(CheckedJavaType.create(assumptions, singleImplementor), receiver, getProfile()));
                 FixedGuardNode guard = graph().add(new FixedGuardNode(condition, DeoptimizationReason.OptimizedTypeCheckViolated, DeoptimizationAction.InvalidateRecompile, false));
                 graph().addBeforeFixed(invoke().asNode(), guard);
                 PiNode piNode = graph().unique(new PiNode(receiver, StampFactory.declaredNonNull(singleImplementor), guard));

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/ConditionalEliminationPhase.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/ConditionalEliminationPhase.java
@@ -412,7 +412,7 @@ public class ConditionalEliminationPhase extends Phase {
                 InstanceOfNode instanceOf = (InstanceOfNode) condition;
                 ValueNode object = instanceOf.getValue();
                 state.addNullness(false, object);
-                state.addType(instanceOf.type(), object);
+                state.addType(instanceOf.type().getType(), object);
             } else if (condition instanceof IsNullNode) {
                 IsNullNode nullCheck = (IsNullNode) condition;
                 state.addNullness(isTrue, nullCheck.getValue());
@@ -649,7 +649,7 @@ public class ConditionalEliminationPhase extends Phase {
                         return falseValue;
                     } else if (state.isNonNull(object)) {
                         ResolvedJavaType type = state.getNodeType(object);
-                        if (type != null && instanceOf.type().isAssignableFrom(type)) {
+                        if (type != null && instanceOf.type().getType().isAssignableFrom(type)) {
                             metricInstanceOfRemoved.increment();
                             return trueValue;
                         }
@@ -818,7 +818,7 @@ public class ConditionalEliminationPhase extends Phase {
             ValueNode object = checkCast.object();
             boolean isNull = state.isNull(object);
             ResolvedJavaType type = state.getNodeType(object);
-            if (isNull || (type != null && checkCast.type().isAssignableFrom(type))) {
+            if (isNull || (type != null && checkCast.type().getType().isAssignableFrom(type))) {
                 boolean nonNull = state.isNonNull(object);
                 // if (true)
                 // throw new RuntimeException(checkCast.toString());

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/ConditionalEliminationPhase.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/ConditionalEliminationPhase.java
@@ -896,7 +896,7 @@ public class ConditionalEliminationPhase extends Phase {
             for (Node n : value.usages()) {
                 if (n instanceof InstanceOfNode) {
                     InstanceOfNode instanceOfNode = (InstanceOfNode) n;
-                    if (instanceOfNode.type().equals(type) && state.trueConditions.containsKey(instanceOfNode)) {
+                    if (instanceOfNode.type().getType().equals(type) && state.trueConditions.containsKey(instanceOfNode)) {
                         GuardingNode v = state.trueConditions.get(instanceOfNode);
                         if (v != null) {
                             return v;

--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/InstanceOfTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/InstanceOfTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import jdk.vm.ci.code.site.Call;
 import jdk.vm.ci.code.site.Mark;
 import jdk.vm.ci.code.site.Site;
@@ -62,7 +63,7 @@ public class InstanceOfTest extends TypeCheckTest {
     protected void replaceProfile(StructuredGraph graph, JavaTypeProfile profile) {
         InstanceOfNode ion = graph.getNodes().filter(InstanceOfNode.class).first();
         if (ion != null) {
-            LogicNode ionNew = graph.unique(InstanceOfNode.create(ion.type(), ion.getValue(), profile));
+            LogicNode ionNew = graph.unique(InstanceOfNode.create(CheckedJavaType.create(graph.getAssumptions(), ion.type().getType()), ion.getValue(), profile));
             ion.replaceAtUsagesAndDelete(ionNew);
         }
     }

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/DefaultJavaLoweringProvider.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/DefaultJavaLoweringProvider.java
@@ -48,6 +48,7 @@ import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaType;
 
 import com.oracle.graal.api.replacements.SnippetReflectionProvider;
+import com.oracle.graal.compiler.common.type.CheckedJavaType;
 import com.oracle.graal.compiler.common.type.IntegerStamp;
 import com.oracle.graal.compiler.common.type.ObjectStamp;
 import com.oracle.graal.compiler.common.type.Stamp;
@@ -331,7 +332,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
             if (arrayType != null && StampTool.isExactType(array)) {
                 ResolvedJavaType elementType = arrayType.getComponentType();
                 if (!elementType.isJavaLangObject()) {
-                    ValueNode storeCheck = CheckCastNode.create(elementType, value, null, true, graph.getAssumptions());
+                    ValueNode storeCheck = CheckCastNode.create(CheckedJavaType.create(storeIndexed.graph().getAssumptions(), elementType), value, null, true);
                     if (storeCheck.graph() == null) {
                         checkCastNode = (CheckCastNode) storeCheck;
                         checkCastNode = graph.add(checkCastNode);

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/StandardGraphBuilderPlugins.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/StandardGraphBuilderPlugins.java
@@ -458,7 +458,7 @@ public class StandardGraphBuilderPlugins {
         Registration r = new Registration(plugins, Class.class);
         r.register2("isInstance", Receiver.class, Object.class, new InvocationPlugin() {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver type, ValueNode object) {
-                LogicNode condition = b.add(InstanceOfDynamicNode.create(b.getConstantReflection(), type.get(), object));
+                LogicNode condition = b.add(InstanceOfDynamicNode.create(b.getAssumptions(), b.getConstantReflection(), type.get(), object));
                 b.push(JavaKind.Boolean, b.recursiveAppend(new ConditionalNode(condition).canonical(null)));
                 return true;
             }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
@@ -446,10 +446,10 @@ public class PartialEvaluator {
         HashMap<String, ArrayList<ValueNode>> groupedByType;
         groupedByType = new HashMap<>();
         for (CheckCastNode cast : graph.getNodes().filter(CheckCastNode.class)) {
-            if (cast.type().findLeafConcreteSubtype() == null) {
+            if (!cast.type().isExactType()) {
                 warnings.add(cast);
-                groupedByType.putIfAbsent(cast.type().getName(), new ArrayList<>());
-                groupedByType.get(cast.type().getName()).add(cast);
+                groupedByType.putIfAbsent(cast.type().getType().getName(), new ArrayList<>());
+                groupedByType.get(cast.type().getType().getName()).add(cast);
             }
         }
         for (Map.Entry<String, ArrayList<ValueNode>> entry : groupedByType.entrySet()) {
@@ -458,10 +458,10 @@ public class PartialEvaluator {
 
         groupedByType = new HashMap<>();
         for (InstanceOfNode instanceOf : graph.getNodes().filter(InstanceOfNode.class)) {
-            if (instanceOf.type().findLeafConcreteSubtype() == null) {
+            if (!instanceOf.type().isExactType()) {
                 warnings.add(instanceOf);
-                groupedByType.putIfAbsent(instanceOf.type().getName(), new ArrayList<>());
-                groupedByType.get(instanceOf.type().getName()).add(instanceOf);
+                groupedByType.putIfAbsent(instanceOf.type().getType().getName(), new ArrayList<>());
+                groupedByType.get(instanceOf.type().getType().getName()).add(instanceOf);
             }
         }
         for (Map.Entry<String, ArrayList<ValueNode>> entry : groupedByType.entrySet()) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
@@ -55,12 +55,12 @@ import com.oracle.graal.nodes.StructuredGraph.AllowAssumptions;
 import com.oracle.graal.nodes.ValueNode;
 import com.oracle.graal.nodes.calc.FloatingNode;
 import com.oracle.graal.nodes.graphbuilderconf.GraphBuilderConfiguration;
+import com.oracle.graal.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import com.oracle.graal.nodes.graphbuilderconf.GraphBuilderContext;
 import com.oracle.graal.nodes.graphbuilderconf.InlineInvokePlugin;
 import com.oracle.graal.nodes.graphbuilderconf.InvocationPlugins;
 import com.oracle.graal.nodes.graphbuilderconf.LoopExplosionPlugin;
 import com.oracle.graal.nodes.graphbuilderconf.ParameterPlugin;
-import com.oracle.graal.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import com.oracle.graal.nodes.java.CheckCastNode;
 import com.oracle.graal.nodes.java.InstanceOfNode;
 import com.oracle.graal.nodes.java.MethodCallTargetNode;
@@ -446,10 +446,10 @@ public class PartialEvaluator {
         HashMap<String, ArrayList<ValueNode>> groupedByType;
         groupedByType = new HashMap<>();
         for (CheckCastNode cast : graph.getNodes().filter(CheckCastNode.class)) {
-            if (!cast.type().isExactType()) {
+            if (!cast.type().isExact()) {
                 warnings.add(cast);
-                groupedByType.putIfAbsent(cast.type().getType().getName(), new ArrayList<>());
-                groupedByType.get(cast.type().getType().getName()).add(cast);
+                groupedByType.putIfAbsent(cast.type().getName(), new ArrayList<>());
+                groupedByType.get(cast.type().getName()).add(cast);
             }
         }
         for (Map.Entry<String, ArrayList<ValueNode>> entry : groupedByType.entrySet()) {
@@ -458,10 +458,10 @@ public class PartialEvaluator {
 
         groupedByType = new HashMap<>();
         for (InstanceOfNode instanceOf : graph.getNodes().filter(InstanceOfNode.class)) {
-            if (!instanceOf.type().isExactType()) {
+            if (!instanceOf.type().isExact()) {
                 warnings.add(instanceOf);
-                groupedByType.putIfAbsent(instanceOf.type().getType().getName(), new ArrayList<>());
-                groupedByType.get(instanceOf.type().getType().getName()).add(instanceOf);
+                groupedByType.putIfAbsent(instanceOf.type().getName(), new ArrayList<>());
+                groupedByType.get(instanceOf.type().getName()).add(instanceOf);
             }
         }
         for (Map.Entry<String, ArrayList<ValueNode>> entry : groupedByType.entrySet()) {


### PR DESCRIPTION
Introduce `CheckedJavaType` and remove duplicate creations of `Assumption` for exact types.
This refactoring should simplify the usage of assumptions and make it less error-prone.

Review by @thomaswue 