### PR TITLE
Make hasOutgoingStackArguments protected

### DIFF
--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/framemap/FrameMap.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/framemap/FrameMap.java
@@ -85,7 +85,7 @@ public abstract class FrameMap {
     /**
      * Determines if this frame has values on the stack for outgoing calls.
      */
-    private boolean hasOutgoingStackArguments;
+    protected boolean hasOutgoingStackArguments;
 
     /**
      * The list of stack slots allocated in this frame that are present in every reference map.


### PR DESCRIPTION
This allows subclasses to check that value when overriding `frameNeedsAllocating()`