### PR TITLE
Restore old behavior for FrameInstance#getCallNode()

### DIFF
--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/builtins/SLGenerateDummyNodesBuiltin.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/builtins/SLGenerateDummyNodesBuiltin.java
@@ -47,7 +47,7 @@ public abstract class SLGenerateDummyNodesBuiltin extends SLGraalRuntimeBuiltin 
     @Specialization
     public Object generateNodes(long count) {
         CompilerAsserts.neverPartOfCompilation("generateNodes should never get optimized.");
-        FrameInstance callerFrame = Truffle.getRuntime().getCurrentFrame();
+        FrameInstance callerFrame = Truffle.getRuntime().getCallerFrame();
         SLRootNode root = (SLRootNode) callerFrame.getCallNode().getRootNode();
         root.getBodyNode().replace(createBinaryTree((int) (count - 1)));
         return SLNull.SINGLETON;

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalFrameInstance.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalFrameInstance.java
@@ -60,15 +60,9 @@ public final class GraalFrameInstance implements FrameInstance {
     private InspectedFrame callNodeFrame;
     private final boolean currentFrame;
 
-    public GraalFrameInstance(boolean currentFrame) {
+    public GraalFrameInstance(boolean currentFrame, InspectedFrame callTargetFrame, InspectedFrame callNodeFrame) {
         this.currentFrame = currentFrame;
-    }
-
-    void setCallTargetFrame(InspectedFrame callTargetFrame) {
         this.callTargetFrame = callTargetFrame;
-    }
-
-    void setCallNodeFrame(InspectedFrame callNodeFrame) {
         this.callNodeFrame = callNodeFrame;
     }
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -41,15 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import jdk.vm.ci.code.BailoutException;
-import jdk.vm.ci.code.stack.InspectedFrame;
-import jdk.vm.ci.code.stack.InspectedFrameVisitor;
-import jdk.vm.ci.code.stack.StackIntrospection;
-import jdk.vm.ci.common.JVMCIError;
-import jdk.vm.ci.meta.MetaAccessProvider;
-import jdk.vm.ci.meta.ResolvedJavaMethod;
-import jdk.vm.ci.services.Services;
-
 import com.oracle.graal.api.runtime.GraalRuntime;
 import com.oracle.graal.code.CompilationResult;
 import com.oracle.graal.compiler.CompilerThreadFactory;
@@ -82,6 +73,15 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RepeatingNode;
 import com.oracle.truffle.api.nodes.RootNode;
+
+import jdk.vm.ci.code.BailoutException;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jdk.vm.ci.code.stack.InspectedFrameVisitor;
+import jdk.vm.ci.code.stack.StackIntrospection;
+import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.services.Services;
 
 public abstract class GraalTruffleRuntime implements TruffleRuntime {
 
@@ -252,10 +252,10 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
         private final ResolvedJavaMethod callTargetMethod;
         private final ResolvedJavaMethod callNodeMethod;
 
-        private GraalFrameInstance next;
-        private boolean nextAvailable;
         private boolean first = true;
         private int skipFrames;
+
+        private InspectedFrame callNodeFrame;
 
         FrameVisitor(FrameInstanceVisitor<T> visitor, CallMethods methods, int skip) {
             this.visitor = visitor;
@@ -265,61 +265,25 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
         }
 
         public T visitFrame(InspectedFrame frame) {
-            if (nextAvailable) {
-                T result = onNext(frame);
-                if (result != null) {
-                    return result;
-                }
-            }
             if (frame.isMethod(callTargetMethod)) {
-                nextAvailable = true;
                 if (skipFrames == 0) {
-                    GraalFrameInstance graalFrame = new GraalFrameInstance(first);
-                    graalFrame.setCallTargetFrame(frame);
-                    next = graalFrame;
+                    return visitor.visitFrame(new GraalFrameInstance(first, frame, callNodeFrame));
+                } else {
+                    skipFrames--;
                 }
                 first = false;
+                callNodeFrame = null;
+            } else if (frame.isMethod(callNodeMethod)) {
+                callNodeFrame = frame;
             }
             return null;
         }
-
-        private T onNext(InspectedFrame frame) {
-            try {
-                if (skipFrames == 0) {
-                    if (frame != null && frame.isMethod(callNodeMethod)) {
-                        next.setCallNodeFrame(frame);
-                    }
-                    return visitor.visitFrame(next);
-                } else {
-                    skipFrames--;
-                    return null;
-                }
-            } finally {
-                next = null;
-                nextAvailable = false;
-            }
-        }
-
-        /* Method to collect the last result. */
-        public T afterVisitation() {
-            if (nextAvailable) {
-                return onNext(null);
-            } else {
-                return null;
-            }
-        }
-
     }
 
     private <T> T iterateImpl(FrameInstanceVisitor<T> visitor, final int skip) {
         CallMethods methods = getCallMethods();
         FrameVisitor<T> jvmciVisitor = new FrameVisitor<>(visitor, methods, skip);
-        T result = getStackIntrospection().iterateFrames(methods.anyFrameMethod, methods.anyFrameMethod, 0, jvmciVisitor);
-        if (result != null) {
-            return result;
-        } else {
-            return jvmciVisitor.afterVisitation();
-        }
+        return getStackIntrospection().iterateFrames(methods.anyFrameMethod, methods.anyFrameMethod, 0, jvmciVisitor);
     }
 
     protected abstract StackIntrospection getStackIntrospection();

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -47,7 +47,7 @@ suite = {
             },
             {
                "name" : "truffle",
-               "version" : "da131e23814fb5c7054f0b59a0bf141e56edc0c4",
+               "version" : "7de96d3ba72f2d1a2a0ef39351a3db4764c74b9c",
                "urls" : [
                     {"url" : "https://github.com/graalvm/truffle.git", "kind" : "git"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
Currently requires https://github.com/graalvm/truffle/pull/90 to work until its integrated.