### PR TITLE
Cleanup and refactor OSR; Move to local counters instead of a global counter in CallTarget; Implemented revirtualization of local variables usable by internal API. Added OSR test suite.

### DIFF
--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/OptimizedOSRLoopNodeTest.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/OptimizedOSRLoopNodeTest.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.truffle.test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import com.oracle.graal.truffle.GraalTruffleRuntime;
+import com.oracle.graal.truffle.OptimizedCallTarget;
+import com.oracle.graal.truffle.OptimizedOSRLoopNode;
+import com.oracle.graal.truffle.TruffleCompilerOptions;
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameInstance;
+import com.oracle.truffle.api.frame.FrameInstanceVisitor;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.LoopNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RepeatingNode;
+import com.oracle.truffle.api.nodes.RootNode;
+
+@RunWith(Theories.class)
+public class OptimizedOSRLoopNodeTest {
+
+    private static final GraalTruffleRuntime runtime = (GraalTruffleRuntime) Truffle.getRuntime();
+
+    private static final int OSR_THRESHOLD = TruffleCompilerOptions.TruffleOSRCompilationThreshold.getValue();
+    private static final int OSR_INVALIDATION_REPROFILE = TruffleCompilerOptions.TruffleInvalidationReprofileCount.getValue();
+
+    @DataPoint public static final OSRLoopFactory CONFIGURED = (repeating, readFrameSlots,
+                    writtenFrameSlots) -> OptimizedOSRLoopNode.createOSRLoop(repeating, OSR_THRESHOLD,
+                                    OSR_INVALIDATION_REPROFILE,
+                                    readFrameSlots, writtenFrameSlots);
+
+    @DataPoint public static final OSRLoopFactory DEFAULT = (repeating, readFrameSlots,
+                    writtenFrameSlots) -> (OptimizedOSRLoopNode) OptimizedOSRLoopNode.create(repeating);
+
+    /*
+     * Test that we achieve compilation on the first execution with a loop invoked
+     */
+    @Theory
+    public void testOSRSingleInvocation(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        CallTarget target = runtime.createCallTarget(rootNode);
+        target.call(OSR_THRESHOLD + 1);
+        assertCompiled(rootNode.getOSRTarget());
+        target.call(2);
+        assertCompiled(rootNode.getOSRTarget());
+        Assert.assertTrue(rootNode.wasRepeatingCalledCompiled());
+    }
+
+    /*
+     * Test OSR is not triggered just below the osr threshold.
+     */
+    @Theory
+    public void testNonOSR(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        runtime.createCallTarget(rootNode).call(OSR_THRESHOLD);
+        assertNotCompiled(rootNode.getOSRTarget());
+    }
+
+    /*
+     * Test frame slot changes in the loop cause deoptimization and reoptimization.
+     */
+    @Test
+    public void testOSRFrameSlotChangeDuringOSR() {
+        OSRLoopFactory factory = CONFIGURED;
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode() {
+
+            @Override
+            public boolean executeRepeating(VirtualFrame frame) {
+                boolean next = super.executeRepeating(frame);
+                if (!next) {
+                    // might trigger a deopt
+                    frame.setDouble(param2, 42.0);
+                }
+                return next;
+            }
+
+        }) {
+
+            @Override
+            public Object execute(VirtualFrame frame) {
+                Object result = super.execute(frame);
+                try {
+                    Assert.assertEquals(42.0d, frame.getDouble(param2), 0.01);
+                } catch (FrameSlotTypeException e) {
+                    Assert.fail();
+                }
+                return result;
+            }
+
+        };
+
+        executeNoCallTarget(rootNode, OSR_THRESHOLD + 1);
+        assertCompiled(rootNode.getOSRTarget());
+        executeNoCallTarget(rootNode, 1);
+        assertNotCompiled(rootNode.getOSRTarget()); // now deoptimized
+        executeNoCallTarget(rootNode, OSR_INVALIDATION_REPROFILE + 1);
+        assertCompiled(rootNode.getOSRTarget());
+        executeNoCallTarget(rootNode, 1); // not deoptimizing
+        assertCompiled(rootNode.getOSRTarget());
+        Assert.assertTrue(rootNode.wasRepeatingCalledCompiled());
+    }
+
+    /*
+     * Test that if osr compilation is forced without any execution we do not deoptimize on first
+     * execution.
+     */
+    @Theory
+    public void testNoInvalidationWithoutFirstExecution(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        RootCallTarget target = runtime.createCallTarget(rootNode);
+        rootNode.forceOSR();
+        assertCompiled(rootNode.getOSRTarget());
+        target.call(1); // should not invalidate OSR
+        assertCompiled(rootNode.getOSRTarget());
+        Assert.assertTrue(rootNode.wasRepeatingCalledCompiled());
+    }
+
+    /*
+     * Test that OSR compilation also works if the loop node is not embedded in a CallTarget, but
+     * just called directly with the node's execute method.
+     */
+    @Theory
+    public void testExecutionWithoutCallTarget(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        executeNoCallTarget(rootNode, OSR_THRESHOLD + 1);
+        assertCompiled(rootNode.getOSRTarget());
+    }
+
+    /*
+     * Test behavior of invalidations when the come from the outside and that it respects the
+     * TruffleInvalidationReprofileCount.
+     */
+    @Theory
+    public void testExternalInvalidations(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        executeNoCallTarget(rootNode, OSR_THRESHOLD + 1);
+        assertCompiled(rootNode.getOSRTarget());
+
+        for (int i = 0; i < 10; i++) {
+            rootNode.getOSRTarget().invalidate();
+            Assert.assertNotNull(rootNode.getOSRTarget());
+            assertNotCompiled(rootNode.getOSRTarget());
+            Assert.assertNotNull(rootNode.getOSRTarget()); // no eager cleanup for thread safety
+
+            for (int j = 0; j < OSR_INVALIDATION_REPROFILE; j++) {
+                executeNoCallTarget(rootNode, 1); // now it should get cleaned up
+                Assert.assertNull(rootNode.getOSRTarget());
+            }
+
+            executeNoCallTarget(rootNode, 1); // now it should get cleaned up
+            assertCompiled(rootNode.getOSRTarget());
+        }
+    }
+
+    /*
+     * Test behavior of OSR compile loops if the invalidate internally during loop execution. Also
+     * test that it respects the invalidation reprofile count.
+     */
+    @Theory
+    public void testInternalInvalidations(OSRLoopFactory factory) {
+        TestRepeatingNode repeating = new TestRepeatingNode();
+        TestRootNode rootNode = new TestRootNode(factory, repeating);
+        CallTarget target = runtime.createCallTarget(rootNode);
+        target.call(OSR_THRESHOLD + 1);
+        assertCompiled(rootNode.getOSRTarget());
+
+        repeating.invalidationCounter = 5;
+        target.call(4);
+        assertCompiled(rootNode.getOSRTarget());
+        target.call(2); // should trigger invalidation
+        assertNotCompiled(rootNode.getOSRTarget());
+    }
+
+    /*
+     * Test that if a call target is called a min invocation thresholöd times it is unlikely that it
+     * needs OSR at all.
+     */
+    @Theory
+    public void testNoOSRAfterMinInvocationThreshold(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        RootCallTarget target = runtime.createCallTarget(rootNode);
+        int i;
+        for (i = 0; i < TruffleCompilerOptions.TruffleMinInvokeThreshold.getValue(); i++) {
+            target.call(0);
+            assertNotCompiled(rootNode.getOSRTarget());
+        }
+        target.call(OSR_THRESHOLD);
+        assertNotCompiled(rootNode.getOSRTarget());
+    }
+
+    /*
+     * Test that loop counts of osr loops propagate loop counts the parent call target.
+     */
+    @Theory
+    public void testOSRMinInvocationThresholdPropagateLoopCounts(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        OptimizedCallTarget target = (OptimizedCallTarget) runtime.createCallTarget(rootNode);
+        int osrThreshold = OSR_THRESHOLD;
+        int truffleMinInvokes = TruffleCompilerOptions.TruffleMinInvokeThreshold.getValue();
+
+        int i;
+        int invokesleft = osrThreshold;
+        for (i = 0; i < truffleMinInvokes - 1; i++) {
+            int invokes = osrThreshold / truffleMinInvokes;
+            invokesleft -= invokes;
+            target.call(invokes);
+            assertNotCompiled(rootNode.getOSRTarget());
+        }
+        assertNotCompiled(target);
+        /*
+         * This should trigger OSR, but since the parent is compiling/compiled already we won't do
+         * OSR.
+         */
+        target.call(invokesleft + 1);
+        assertNotCompiled(rootNode.getOSRTarget());
+        assertCompiled(target);
+    }
+
+    /*
+     * Test that if the parent call target is just below the min invoke threshold OSR compilation
+     * triggers.
+     */
+    @Theory
+    public void testOSRBelowMinInvokeThreshold(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+        OptimizedCallTarget target = (OptimizedCallTarget) runtime.createCallTarget(rootNode);
+        int osrThreshold = OSR_THRESHOLD;
+        int truffleMinInvokes = TruffleCompilerOptions.TruffleMinInvokeThreshold.getValue();
+
+        int i;
+        int invokesleft = osrThreshold;
+        for (i = 0; i < truffleMinInvokes - 2; i++) {
+            int invokes = 10;
+            invokesleft -= invokes;
+            target.call(invokes);
+            assertNotCompiled(rootNode.getOSRTarget());
+        }
+        assertNotCompiled(target);
+
+        target.call(invokesleft + 1);
+        assertCompiled(rootNode.getOSRTarget());
+        assertNotCompiled(target);
+
+        target.call(1);
+        assertCompiled(target);
+    }
+
+    /*
+     * Test usage and compilation of the osr loop on multiple threads.
+     */
+    @Theory
+    public void testThreadSafety(OSRLoopFactory factory) {
+        int threshold = OSR_THRESHOLD;
+        IntStream.generate(() -> 10).limit(10).parallel().forEach(i -> {
+            TestRootNode rootNode = new TestRootNode(factory, new TestRepeatingNode());
+            IntStream.generate(() -> threshold / 2).limit(10).parallel().forEach(k -> executeNoCallTarget(rootNode, k));
+            assertCompiled(rootNode.getOSRTarget());
+        });
+    }
+
+    /*
+     * Test that two silbling loops are compiled independently.
+     */
+    @Theory
+    public void testTwoLoopsSilblings(OSRLoopFactory factory) {
+        TwoSilblingLoopNodesTest rootNode = new TwoSilblingLoopNodesTest(factory, new TestRepeatingNode(), new TestRepeatingNode());
+        CallTarget target = runtime.createCallTarget(rootNode);
+        target.call(OSR_THRESHOLD + 1, OSR_THRESHOLD);
+        assertCompiled(rootNode.getOSRTarget());
+        assertNotCompiled(rootNode.getOSRTarget2());
+        target.call(0, 1);
+        assertCompiled(rootNode.getOSRTarget());
+        assertCompiled(rootNode.getOSRTarget2());
+        Assert.assertTrue(rootNode.getOSRTarget() != rootNode.getOSRTarget2());
+    }
+
+    private static class TwoSilblingLoopNodesTest extends TestRootNode {
+        @Child OptimizedOSRLoopNode loopNode2;
+
+        protected TwoSilblingLoopNodesTest(OSRLoopFactory factory, TestRepeatingNode repeating1, TestRepeatingNode repeating2) {
+            super(factory, repeating1);
+            loopNode2 = factory.createOSRLoop(repeating2, null, null);
+            repeating2.param1 = param2;
+        }
+
+        public OptimizedCallTarget getOSRTarget2() {
+            return loopNode2.getCompiledOSRLoop();
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            super.execute(frame);
+            loopNode2.executeLoop(frame);
+            return null;
+        }
+    }
+
+    /*
+     * Test that two loops in a parent child relationship are propagating loop counts.
+     */
+    @Theory
+    public void testTwoLoopsParentChild1(OSRLoopFactory factory) {
+        ChildLoopRepeatingNode childLoop = new ChildLoopRepeatingNode(factory, new TestRepeatingNode(), loop -> {
+            assertNotCompiled(loop.getOSRTarget());
+            return null;
+        });
+        TestRootNode rootNode = new TestRootNode(factory, childLoop);
+        CallTarget target = runtime.createCallTarget(rootNode);
+
+        target.call(1, OSR_THRESHOLD);
+        assertCompiled(rootNode.getOSRTarget());
+        assertNotCompiled(childLoop.getOSRTarget());
+    }
+
+    @Theory
+    public void testTwoLoopsParentChild2(OSRLoopFactory factory) {
+        ChildLoopRepeatingNode childLoop = new ChildLoopRepeatingNode(factory, new TestRepeatingNode(), loop -> {
+            assertCompiled(loop.getOSRTarget());
+            return null;
+        });
+        TestRootNode rootNode = new TestRootNode(factory, childLoop);
+        CallTarget target = runtime.createCallTarget(rootNode);
+
+        target.call(1, OSR_THRESHOLD + 1);
+        assertCompiled(rootNode.getOSRTarget());
+        assertCompiled(childLoop.getOSRTarget());
+    }
+
+    private static class ChildLoopRepeatingNode extends TestRepeatingNode {
+
+        @Child OptimizedOSRLoopNode loopNode2;
+
+        private final Function<ChildLoopRepeatingNode, Void> onBackedge;
+
+        protected ChildLoopRepeatingNode(OSRLoopFactory factory, TestRepeatingNode child, Function<ChildLoopRepeatingNode, Void> onBackedge) {
+            this.loopNode2 = factory.createOSRLoop(child, null, null);
+            this.onBackedge = onBackedge;
+
+        }
+
+        public OptimizedCallTarget getOSRTarget() {
+            return loopNode2.getCompiledOSRLoop();
+        }
+
+        @Override
+        public boolean executeRepeating(VirtualFrame frame) {
+            if (CompilerDirectives.inInterpreter()) {
+                ((TestRepeatingNode) loopNode2.getRepeatingNode()).param1 = param2;
+            }
+            boolean next = super.executeRepeating(frame);
+            if (next) {
+                loopNode2.executeLoop(frame);
+            } else {
+                onBackedge.apply(this);
+            }
+            return next;
+        }
+
+    }
+
+    /*
+     * Test that a custom loop reported using LoopNode#reportLoopCount contributes to the OSR
+     * compilation heuristic.
+     */
+    @Theory
+    public void testCustomLoopContributingToOSR1(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new CustomInnerLoopRepeatingNode());
+        runtime.createCallTarget(rootNode).call(1, OSR_THRESHOLD - 1);
+        assertNotCompiled(rootNode.getOSRTarget());
+        runtime.createCallTarget(rootNode).call(1, 0); // triggers
+        assertCompiled(rootNode.getOSRTarget());
+    }
+
+    @Theory
+    public void testCustomLoopContributingToOSR2(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new CustomInnerLoopRepeatingNode());
+        runtime.createCallTarget(rootNode).call(1, OSR_THRESHOLD);
+        assertCompiled(rootNode.getOSRTarget());
+    }
+
+    @Theory
+    public void testCustomLoopContributingToOSR3(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new CustomInnerLoopRepeatingNode());
+        runtime.createCallTarget(rootNode).call(2, OSR_THRESHOLD / 2);
+        assertCompiled(rootNode.getOSRTarget());
+    }
+
+    @Theory
+    public void testCustomLoopContributingToOSR4(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new CustomInnerLoopRepeatingNode());
+        runtime.createCallTarget(rootNode).call(2, OSR_THRESHOLD / 2 - 1);
+        assertNotCompiled(rootNode.getOSRTarget());
+    }
+
+    private static class CustomInnerLoopRepeatingNode extends TestRepeatingNode {
+
+        @Override
+        public boolean executeRepeating(VirtualFrame frame) {
+            boolean next = super.executeRepeating(frame);
+            if (next) {
+                // its like beeing in body
+                try {
+                    int count = frame.getInt(param2);
+
+                    // imagine loop work with size count here
+
+                    LoopNode.reportLoopCount(this, count);
+
+                } catch (FrameSlotTypeException e) {
+                    throw new AssertionError();
+                }
+            }
+            return next;
+        }
+
+    }
+
+    /*
+     * OSR stack frames should not show up.
+     */
+    @Theory
+    public void testStackTraceDoesNotShowOSR(OSRLoopFactory factory) {
+        TestRootNode rootNode = new TestRootNode(factory, new TestOSRStackTrace());
+        CallTarget target = runtime.createCallTarget(rootNode);
+        target.call(1);
+        rootNode.forceOSR();
+        assertCompiled(rootNode.getOSRTarget());
+        target.call(1);
+        assertCompiled(rootNode.getOSRTarget());
+    }
+
+    private static class TestOSRStackTrace extends TestRepeatingNode {
+
+        @Override
+        public boolean executeRepeating(VirtualFrame frame) {
+            boolean next = super.executeRepeating(frame);
+            if (!next) {
+                checkStackTrace();
+            }
+            return next;
+        }
+
+        @TruffleBoundary
+        private void checkStackTrace() {
+            final OptimizedOSRLoopNode loop = (OptimizedOSRLoopNode) getParent();
+            final OptimizedCallTarget compiledLoop = loop.getCompiledOSRLoop();
+
+            Truffle.getRuntime().iterateFrames(new FrameInstanceVisitor<Void>() {
+                public Void visitFrame(FrameInstance frameInstance) {
+                    Assert.assertNotSame(compiledLoop, frameInstance.getCallTarget());
+                    return null;
+                }
+            });
+        }
+
+    }
+
+    /* Useful to test no dependencies on a root call target. */
+    private static void executeNoCallTarget(TestRootNode rootNode, int count) {
+        rootNode.adoptChildren();
+        rootNode.execute(Truffle.getRuntime().createVirtualFrame(new Object[]{count}, rootNode.getFrameDescriptor()));
+    }
+
+    private static interface OSRLoopFactory {
+        OptimizedOSRLoopNode createOSRLoop(RepeatingNode repeating, FrameSlot[] readFrameSlots, FrameSlot[] writtenframeSlots);
+    }
+
+    private static void assertCompiled(OptimizedCallTarget target) {
+        Assert.assertNotNull(target);
+        try {
+            runtime.waitForCompilation(target, 10000);
+        } catch (ExecutionException | TimeoutException e) {
+            Assert.fail("timeout");
+        }
+        Assert.assertTrue(target.isValid());
+    }
+
+    private static void assertNotCompiled(OptimizedCallTarget target) {
+        if (target != null) {
+            Assert.assertFalse(target.isValid());
+            Assert.assertFalse(target.isCompiling());
+        }
+    }
+
+    private static class TestRootNode extends RootNode {
+
+        @Child OptimizedOSRLoopNode loopNode;
+
+        final FrameSlot param1;
+        final FrameSlot param2;
+
+        protected TestRootNode(OSRLoopFactory factory, TestRepeatingNode repeating) {
+            super(MockLanguage.class, null, new FrameDescriptor());
+            param1 = getFrameDescriptor().addFrameSlot("param1", FrameSlotKind.Int);
+            param2 = getFrameDescriptor().addFrameSlot("param2", FrameSlotKind.Int);
+            loopNode = factory.createOSRLoop(repeating, new FrameSlot[]{param1, param2}, new FrameSlot[]{param1, param2});
+            repeating.param1 = param1;
+            repeating.param2 = param2;
+        }
+
+        public void forceOSR() {
+            loopNode.forceOSR();
+        }
+
+        public OptimizedCallTarget getOSRTarget() {
+            return loopNode.getCompiledOSRLoop();
+        }
+
+        public boolean wasRepeatingCalledCompiled() {
+            return ((TestRepeatingNode) loopNode.getRepeatingNode()).compiled;
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            int nextLoopCount = (int) frame.getArguments()[0];
+            frame.setInt(param1, nextLoopCount);
+            if (frame.getArguments().length > 1) {
+                frame.setInt(param2, (int) frame.getArguments()[1]);
+            } else {
+                frame.setInt(param2, 0);
+            }
+            loopNode.executeLoop(frame);
+            return null;
+        }
+    }
+
+    private static class TestRepeatingNode extends Node implements RepeatingNode {
+        int invalidationCounter = -1;
+
+        @CompilationFinal FrameSlot param1;
+        @CompilationFinal FrameSlot param2;
+
+        boolean compiled;
+
+        public boolean executeRepeating(VirtualFrame frame) {
+            try {
+                if (invalidationCounter >= 0) {
+                    if (invalidationCounter == 0) {
+                        CompilerDirectives.transferToInterpreterAndInvalidate();
+                        invalidationCounter = -1; // disable
+                    } else {
+                        invalidationCounter--;
+                    }
+                }
+
+                if (CompilerDirectives.inCompiledCode()) {
+                    compiled = true;
+                } else {
+                    compiled = false;
+                }
+
+                int counter = frame.getInt(param1);
+                frame.setInt(param1, counter - 1);
+                return counter != 0;
+            } catch (FrameSlotTypeException e) {
+                return false;
+            }
+        }
+
+    }
+
+}

--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/OptimizedOSRLoopNodeTest.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/OptimizedOSRLoopNodeTest.java
@@ -66,8 +66,8 @@ public class OptimizedOSRLoopNodeTest {
 
     @DataPoint public static final OSRLoopFactory CONFIGURED = (repeating, readFrameSlots,
                     writtenFrameSlots) -> OptimizedOSRLoopNode.createOSRLoop(repeating, OSR_THRESHOLD,
-                                    OSR_INVALIDATION_REPROFILE,
-                                    readFrameSlots, writtenFrameSlots);
+                    OSR_INVALIDATION_REPROFILE,
+                    readFrameSlots, writtenFrameSlots);
 
     @DataPoint public static final OSRLoopFactory DEFAULT = (repeating, readFrameSlots,
                     writtenFrameSlots) -> (OptimizedOSRLoopNode) OptimizedOSRLoopNode.create(repeating);

--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/OptimizedOSRLoopNodeTest.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/OptimizedOSRLoopNodeTest.java
@@ -64,10 +64,8 @@ public class OptimizedOSRLoopNodeTest {
     private static final int OSR_THRESHOLD = TruffleCompilerOptions.TruffleOSRCompilationThreshold.getValue();
     private static final int OSR_INVALIDATION_REPROFILE = TruffleCompilerOptions.TruffleInvalidationReprofileCount.getValue();
 
-    @DataPoint public static final OSRLoopFactory CONFIGURED = (repeating, readFrameSlots,
-                    writtenFrameSlots) -> OptimizedOSRLoopNode.createOSRLoop(repeating, OSR_THRESHOLD,
-                    OSR_INVALIDATION_REPROFILE,
-                    readFrameSlots, writtenFrameSlots);
+    @DataPoint public static final OSRLoopFactory CONFIGURED = (repeating, readFrameSlots, writtenFrameSlots) -> OptimizedOSRLoopNode.createOSRLoop(repeating, OSR_THRESHOLD,
+                    OSR_INVALIDATION_REPROFILE, readFrameSlots, writtenFrameSlots);
 
     @DataPoint public static final OSRLoopFactory DEFAULT = (repeating, readFrameSlots,
                     writtenFrameSlots) -> (OptimizedOSRLoopNode) OptimizedOSRLoopNode.create(repeating);
@@ -212,7 +210,7 @@ public class OptimizedOSRLoopNodeTest {
     }
 
     /*
-     * Test that if a call target is called a min invocation thresholöd times it is unlikely that it
+     * Test that if a call target is called a min invocation theshold times it is unlikely that it
      * needs OSR at all.
      */
     @Theory
@@ -501,7 +499,7 @@ public class OptimizedOSRLoopNodeTest {
         rootNode.execute(Truffle.getRuntime().createVirtualFrame(new Object[]{count}, rootNode.getFrameDescriptor()));
     }
 
-    private static interface OSRLoopFactory {
+    private interface OSRLoopFactory {
         OptimizedOSRLoopNode createOSRLoop(RepeatingNode repeating, FrameSlot[] readFrameSlots, FrameSlot[] writtenframeSlots);
     }
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/CompilationProfile.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/CompilationProfile.java
@@ -26,13 +26,11 @@ import static com.oracle.graal.truffle.TruffleCompilerOptions.TruffleCompilation
 import static com.oracle.graal.truffle.TruffleCompilerOptions.TruffleInvalidationReprofileCount;
 import static com.oracle.graal.truffle.TruffleCompilerOptions.TruffleMinInvokeThreshold;
 import static com.oracle.graal.truffle.TruffleCompilerOptions.TruffleReplaceReprofileCount;
-import static com.oracle.graal.truffle.TruffleCompilerOptions.TruffleOSRCompilationThreshold;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CompilationProfile {
-    private static final int RESET_OSR_VALUE = Integer.MAX_VALUE - TruffleOSRCompilationThreshold.getValue();
 
     /**
      * Number of times an installed code for this tree was invalidated.
@@ -45,14 +43,11 @@ public class CompilationProfile {
     private int compilationCallThreshold;
     private int compilationCallAndLoopThreshold;
 
-    private int osrThreshold;
-
     private long timestamp;
 
     public CompilationProfile() {
         compilationCallThreshold = TruffleMinInvokeThreshold.getValue();
         compilationCallAndLoopThreshold = TruffleCompilationThreshold.getValue();
-        osrThreshold = RESET_OSR_VALUE;
     }
 
     @Override
@@ -114,16 +109,7 @@ public class CompilationProfile {
         ensureProfiling(reprofile, reprofile);
     }
 
-    final void reportOSRCompiledLoop() {
-        osrThreshold = RESET_OSR_VALUE;
-    }
-
-    final void reportOSR() throws ArithmeticException {
-        osrThreshold = Math.incrementExact(osrThreshold);
-    }
-
-    public void reportInterpreterCall() {
-        osrThreshold = RESET_OSR_VALUE;
+    public final void reportInterpreterCall() {
         interpreterCallCount++;
         interpreterCallAndLoopCount++;
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/FrameWithoutBoxing.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/FrameWithoutBoxing.java
@@ -24,6 +24,7 @@ package com.oracle.graal.truffle;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.List;
 
 import sun.misc.Unsafe;
 
@@ -104,11 +105,11 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return unsafeCast(this.primitiveLocals, long[].class, true, true);
     }
 
-    private byte[] getTags() {
+    byte[] getTags() {
         return unsafeCast(tags, byte[].class, true, true);
     }
 
-    private Object getObjectUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    Object getObjectUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         return unsafeGetObject(getLocals(), Unsafe.ARRAY_OBJECT_BASE_OFFSET + slotIndex * (long) Unsafe.ARRAY_OBJECT_INDEX_SCALE, condition, slot);
     }
 
@@ -119,7 +120,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setObjectUnsafe(slotIndex, slot, value);
     }
 
-    private void setObjectUnsafe(int slotIndex, FrameSlot slot, Object value) {
+    void setObjectUnsafe(int slotIndex, FrameSlot slot, Object value) {
         unsafePutObject(getLocals(), Unsafe.ARRAY_OBJECT_BASE_OFFSET + slotIndex * (long) Unsafe.ARRAY_OBJECT_INDEX_SCALE, value, slot);
     }
 
@@ -130,7 +131,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return getByteUnsafe(slotIndex, slot, condition);
     }
 
-    private byte getByteUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    byte getByteUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         long offset = getPrimitiveOffset(slotIndex);
         return (byte) unsafeGetInt(getPrimitiveLocals(), offset, condition, slot);
     }
@@ -142,7 +143,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setByteUnsafe(slotIndex, slot, value);
     }
 
-    private void setByteUnsafe(int slotIndex, FrameSlot slot, byte value) {
+    void setByteUnsafe(int slotIndex, FrameSlot slot, byte value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutInt(getPrimitiveLocals(), offset, value, slot);
     }
@@ -154,7 +155,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return getBooleanUnsafe(slotIndex, slot, condition);
     }
 
-    private boolean getBooleanUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    boolean getBooleanUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         long offset = getPrimitiveOffset(slotIndex);
         return unsafeGetInt(getPrimitiveLocals(), offset, condition, slot) != 0;
     }
@@ -166,7 +167,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setBooleanUnsafe(slotIndex, slot, value);
     }
 
-    private void setBooleanUnsafe(int slotIndex, FrameSlot slot, boolean value) {
+    void setBooleanUnsafe(int slotIndex, FrameSlot slot, boolean value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutInt(getPrimitiveLocals(), offset, value ? 1 : 0, slot);
     }
@@ -178,7 +179,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return getFloatUnsafe(slotIndex, slot, condition);
     }
 
-    private float getFloatUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    float getFloatUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         long offset = getPrimitiveOffset(slotIndex);
         return unsafeGetFloat(getPrimitiveLocals(), offset, condition, slot);
     }
@@ -190,7 +191,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setFloatUnsafe(slotIndex, slot, value);
     }
 
-    private void setFloatUnsafe(int slotIndex, FrameSlot slot, float value) {
+    void setFloatUnsafe(int slotIndex, FrameSlot slot, float value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutFloat(getPrimitiveLocals(), offset, value, slot);
     }
@@ -202,7 +203,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return getLongUnsafe(slotIndex, slot, condition);
     }
 
-    private long getLongUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    long getLongUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         long offset = getPrimitiveOffset(slotIndex);
         return unsafeGetLong(getPrimitiveLocals(), offset, condition, slot);
     }
@@ -214,7 +215,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setLongUnsafe(slotIndex, slot, value);
     }
 
-    private void setLongUnsafe(int slotIndex, FrameSlot slot, long value) {
+    void setLongUnsafe(int slotIndex, FrameSlot slot, long value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutLong(getPrimitiveLocals(), offset, value, slot);
     }
@@ -226,7 +227,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return getIntUnsafe(slotIndex, slot, condition);
     }
 
-    private int getIntUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    int getIntUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         long offset = getPrimitiveOffset(slotIndex);
         return unsafeGetInt(getPrimitiveLocals(), offset, condition, slot);
     }
@@ -238,7 +239,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setIntUnsafe(slotIndex, slot, value);
     }
 
-    private void setIntUnsafe(int slotIndex, FrameSlot slot, int value) {
+    void setIntUnsafe(int slotIndex, FrameSlot slot, int value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutInt(getPrimitiveLocals(), offset, value, slot);
     }
@@ -250,7 +251,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return getDoubleUnsafe(slotIndex, slot, condition);
     }
 
-    private double getDoubleUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
+    double getDoubleUnsafe(int slotIndex, FrameSlot slot, boolean condition) {
         long offset = getPrimitiveOffset(slotIndex);
         return unsafeGetDouble(getPrimitiveLocals(), offset, condition, slot);
     }
@@ -262,7 +263,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setDoubleUnsafe(slotIndex, slot, value);
     }
 
-    private void setDoubleUnsafe(int slotIndex, FrameSlot slot, double value) {
+    void setDoubleUnsafe(int slotIndex, FrameSlot slot, double value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutDouble(getPrimitiveLocals(), offset, value, slot);
     }
@@ -350,7 +351,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         return false;
     }
 
-    private byte getTag(FrameSlot slot) {
+    byte getTag(FrameSlot slot) {
         int slotIndex = slot.getIndex();
         byte[] cachedTags = getTags();
         if (slotIndex < cachedTags.length) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/FrameWithoutBoxing.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/FrameWithoutBoxing.java
@@ -24,9 +24,6 @@ package com.oracle.graal.truffle;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.List;
-
-import sun.misc.Unsafe;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameDescriptor;
@@ -35,6 +32,8 @@ import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
+
+import sun.misc.Unsafe;
 
 /**
  * More efficient implementation of the Truffle frame that has no safety checks for frame accesses
@@ -120,7 +119,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setObjectUnsafe(slotIndex, slot, value);
     }
 
-    void setObjectUnsafe(int slotIndex, FrameSlot slot, Object value) {
+    private void setObjectUnsafe(int slotIndex, FrameSlot slot, Object value) {
         unsafePutObject(getLocals(), Unsafe.ARRAY_OBJECT_BASE_OFFSET + slotIndex * (long) Unsafe.ARRAY_OBJECT_INDEX_SCALE, value, slot);
     }
 
@@ -143,7 +142,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setByteUnsafe(slotIndex, slot, value);
     }
 
-    void setByteUnsafe(int slotIndex, FrameSlot slot, byte value) {
+    private void setByteUnsafe(int slotIndex, FrameSlot slot, byte value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutInt(getPrimitiveLocals(), offset, value, slot);
     }
@@ -167,7 +166,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setBooleanUnsafe(slotIndex, slot, value);
     }
 
-    void setBooleanUnsafe(int slotIndex, FrameSlot slot, boolean value) {
+    private void setBooleanUnsafe(int slotIndex, FrameSlot slot, boolean value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutInt(getPrimitiveLocals(), offset, value ? 1 : 0, slot);
     }
@@ -191,7 +190,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setFloatUnsafe(slotIndex, slot, value);
     }
 
-    void setFloatUnsafe(int slotIndex, FrameSlot slot, float value) {
+    private void setFloatUnsafe(int slotIndex, FrameSlot slot, float value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutFloat(getPrimitiveLocals(), offset, value, slot);
     }
@@ -215,7 +214,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setLongUnsafe(slotIndex, slot, value);
     }
 
-    void setLongUnsafe(int slotIndex, FrameSlot slot, long value) {
+    private void setLongUnsafe(int slotIndex, FrameSlot slot, long value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutLong(getPrimitiveLocals(), offset, value, slot);
     }
@@ -239,7 +238,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setIntUnsafe(slotIndex, slot, value);
     }
 
-    void setIntUnsafe(int slotIndex, FrameSlot slot, int value) {
+    private void setIntUnsafe(int slotIndex, FrameSlot slot, int value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutInt(getPrimitiveLocals(), offset, value, slot);
     }
@@ -263,7 +262,7 @@ public final class FrameWithoutBoxing implements VirtualFrame, MaterializedFrame
         setDoubleUnsafe(slotIndex, slot, value);
     }
 
-    void setDoubleUnsafe(int slotIndex, FrameSlot slot, double value) {
+    private void setDoubleUnsafe(int slotIndex, FrameSlot slot, double value) {
         long offset = getPrimitiveOffset(slotIndex);
         unsafePutDouble(getPrimitiveLocals(), offset, value, slot);
     }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalFrameInstance.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalFrameInstance.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import jdk.vm.ci.code.stack.InspectedFrame;
 import jdk.vm.ci.common.JVMCIError;
 
+import com.oracle.graal.truffle.OptimizedOSRLoopNode.OSRRootNode;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.Frame;
@@ -46,11 +47,13 @@ public final class GraalFrameInstance implements FrameInstance {
 
     public static final Method CALL_TARGET_METHOD;
     public static final Method CALL_NODE_METHOD;
+    public static final Method CALL_OSR_METHOD;
 
     static {
         try {
             CALL_NODE_METHOD = OptimizedDirectCallNode.class.getDeclaredMethod("callProxy", MaterializedFrameNotify.class, CallTarget.class, VirtualFrame.class, Object[].class, boolean.class);
             CALL_TARGET_METHOD = OptimizedCallTarget.class.getDeclaredMethod("callProxy", VirtualFrame.class);
+            CALL_OSR_METHOD = OptimizedOSRLoopNode.OSRRootNode.class.getDeclaredMethod("callProxy", OSRRootNode.class, VirtualFrame.class);
         } catch (NoSuchMethodException | SecurityException e) {
             throw new JVMCIError(e);
         }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -264,7 +264,7 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
         }
 
         public T visitFrame(InspectedFrame frame) {
-			if (frame.isMethod(methods.callOSRMethod)) {
+            if (frame.isMethod(methods.callOSRMethod)) {
                 // we ignore OSR frames.
                 skipFrames++;
                 return null;

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -250,8 +250,7 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
     private static final class FrameVisitor<T> implements InspectedFrameVisitor<T> {
 
         private final FrameInstanceVisitor<T> visitor;
-        private final ResolvedJavaMethod callTargetMethod;
-        private final ResolvedJavaMethod callNodeMethod;
+        private final CallMethods methods;
 
         private boolean first = true;
         private int skipFrames;
@@ -260,13 +259,16 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
 
         FrameVisitor(FrameInstanceVisitor<T> visitor, CallMethods methods, int skip) {
             this.visitor = visitor;
-            this.callTargetMethod = methods.callTargetMethod;
-            this.callNodeMethod = methods.callNodeMethod;
+            this.methods = methods;
             this.skipFrames = skip;
         }
 
         public T visitFrame(InspectedFrame frame) {
-            if (frame.isMethod(callTargetMethod)) {
+			if (frame.isMethod(methods.callOSRMethod)) {
+                // we ignore OSR frames.
+                skipFrames++;
+                return null;
+            } else if (frame.isMethod(methods.callTargetMethod)) {
                 try {
                     if (skipFrames == 0) {
                         return visitor.visitFrame(new GraalFrameInstance(first, frame, callNodeFrame));
@@ -277,7 +279,7 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
                     callNodeFrame = null;
                     first = false;
                 }
-            } else if (frame.isMethod(callNodeMethod)) {
+            } else if (frame.isMethod(methods.callNodeMethod)) {
                 callNodeFrame = frame;
             }
             return null;
@@ -569,12 +571,14 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
     protected static final class CallMethods {
         public final ResolvedJavaMethod callNodeMethod;
         public final ResolvedJavaMethod callTargetMethod;
+        public final ResolvedJavaMethod callOSRMethod;
         public final ResolvedJavaMethod[] anyFrameMethod;
 
         private CallMethods(MetaAccessProvider metaAccess) {
             this.callNodeMethod = metaAccess.lookupJavaMethod(GraalFrameInstance.CALL_NODE_METHOD);
             this.callTargetMethod = metaAccess.lookupJavaMethod(GraalFrameInstance.CALL_TARGET_METHOD);
-            this.anyFrameMethod = new ResolvedJavaMethod[]{callNodeMethod, callTargetMethod};
+            this.callOSRMethod = metaAccess.lookupJavaMethod(GraalFrameInstance.CALL_OSR_METHOD);
+            this.anyFrameMethod = new ResolvedJavaMethod[]{callNodeMethod, callTargetMethod, callOSRMethod};
         }
 
         public static CallMethods lookup(MetaAccessProvider metaAccess) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
@@ -76,7 +76,8 @@ import jdk.vm.ci.meta.SpeculationLog;
 /**
  * Call target that is optimized by Graal upon surpassing a specific invocation threshold.
  */
-public class OptimizedCallTarget extends InstalledCode implements RootCallTarget, ReplaceObserver {
+@SuppressWarnings("deprecation")
+public class OptimizedCallTarget extends InstalledCode implements RootCallTarget, ReplaceObserver, com.oracle.truffle.api.LoopCountReceiver {
     private static final RootNode UNINITIALIZED = RootNode.createConstantNode(null);
 
     protected final GraalTruffleRuntime runtime;
@@ -489,7 +490,7 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         return castArguments;
     }
 
-    private static Object castArrayFixedLength(Object[] args, @SuppressWarnings("unused") int length) {
+    private static Object castArrayFixedLength(Object[] args, int length) {
         return args;
     }
 
@@ -515,6 +516,13 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
     }
 
     final void onLoopCount(int count) {
+        compilationProfile.reportLoopCount(count);
+    }
+
+    /*
+     * For compatibility of Graal runtime with older Truffle runtime. Remove after 0.12.
+     */
+    public void reportLoopCount(int count) {
         compilationProfile.reportLoopCount(count);
     }
 
@@ -598,7 +606,7 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         return DefaultCompilerOptions.INSTANCE;
     }
 
-    @SuppressWarnings({"unchecked", "unused"})
+    @SuppressWarnings({"unchecked"})
     private static <T> T unsafeCast(Object value, Class<T> type, boolean condition, boolean nonNull) {
         return (T) value;
     }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
@@ -46,15 +46,16 @@ import java.util.stream.StreamSupport;
 
 import com.oracle.graal.truffle.debug.AbstractDebugCompilationListener;
 import com.oracle.truffle.api.Assumption;
+import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerOptions;
-import com.oracle.truffle.api.LoopCountReceiver;
 import com.oracle.truffle.api.OptimizationFailedException;
 import com.oracle.truffle.api.ReplaceObserver;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.impl.Accessor;
@@ -75,7 +76,7 @@ import jdk.vm.ci.meta.SpeculationLog;
 /**
  * Call target that is optimized by Graal upon surpassing a specific invocation threshold.
  */
-public class OptimizedCallTarget extends InstalledCode implements RootCallTarget, LoopCountReceiver, ReplaceObserver {
+public class OptimizedCallTarget extends InstalledCode implements RootCallTarget, ReplaceObserver {
     private static final RootNode UNINITIALIZED = RootNode.createConstantNode(null);
 
     protected final GraalTruffleRuntime runtime;
@@ -513,8 +514,7 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         return callNodes;
     }
 
-    @Override
-    public void reportLoopCount(int count) {
+    final void onLoopCount(int count) {
         compilationProfile.reportLoopCount(count);
     }
 
@@ -632,13 +632,44 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         this.compilationTask = compilationTask;
     }
 
-    private static final AccessorOptimizedCallTarget ACCESSOR = new AccessorOptimizedCallTarget();
+    static final AccessorOptimizedCallTarget ACCESSOR = new AccessorOptimizedCallTarget();
 
     static final class AccessorOptimizedCallTarget extends Accessor {
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        protected Class<? extends TruffleLanguage> findLanguage(RootNode n) {
+            return super.findLanguage(n);
+        }
 
         @Override
         protected void initializeCallTarget(RootCallTarget target) {
             super.initializeCallTarget(target);
         }
+
+        @Override
+        protected boolean supportsOnLoopCount() {
+            return true;
+        }
+
+        @Override
+        protected void onLoopCount(Node source, int count) {
+            Node node = source;
+            Node parentNode = source != null ? source.getParent() : null;
+            while (node != null) {
+                if (node instanceof OptimizedOSRLoopNode) {
+                    ((OptimizedOSRLoopNode) node).reportChildLoopCount(count);
+                }
+                parentNode = node;
+                node = node.getParent();
+            }
+            if (parentNode != null && parentNode instanceof RootNode) {
+                CallTarget target = ((RootNode) parentNode).getCallTarget();
+                if (target instanceof OptimizedCallTarget) {
+                    ((OptimizedCallTarget) target).onLoopCount(count);
+                }
+            }
+        }
+
     }
 }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedLoopNode.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedLoopNode.java
@@ -27,10 +27,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.RepeatingNode;
 
-/**
- * Temporary node for legacy loop count reporting support as it was most likely done in other
- * implementations.
- */
 public final class OptimizedLoopNode extends LoopNode {
 
     @Child private RepeatingNode repeatingNode;
@@ -55,9 +51,13 @@ public final class OptimizedLoopNode extends LoopNode {
             }
         } finally {
             if (CompilerDirectives.inInterpreter()) {
-                getRootNode().reportLoopCount(loopCount);
+                reportLoopCount(this, loopCount);
             }
         }
+    }
+
+    static LoopNode create(RepeatingNode repeatingNode) {
+        return new OptimizedLoopNode(repeatingNode);
     }
 
 }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
@@ -352,7 +352,7 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
      */
     private static final class OptimizedDefaultOSRLoopNode extends OptimizedOSRLoopNode {
 
-        public OptimizedDefaultOSRLoopNode(RepeatingNode repeatableNode, int osrThreshold) {
+        OptimizedDefaultOSRLoopNode(RepeatingNode repeatableNode, int osrThreshold) {
             super(repeatableNode, osrThreshold);
         }
 
@@ -367,7 +367,7 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
      * Used in guest languages with Graal runtime access that require more revirtualization of local
      * variables and more configuration options.
      */
-    private static class OptimizedVirtualizingOSRLoopNode extends OptimizedOSRLoopNode {
+    private static final class OptimizedVirtualizingOSRLoopNode extends OptimizedOSRLoopNode {
 
         private final int invalidationBackoff;
         @CompilationFinal private final FrameSlot[] readFrameSlots;

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
@@ -312,13 +312,13 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
     /**
      * <p>
      * Creates a configurable instance of the OSR loop node. If readFrameSlots and writtenFrameSlots
-     * is set then the involved frame must never escape, ie {@link VirtualFrame#materialize()} is
+     * are set then the involved frame must never escape, ie {@link VirtualFrame#materialize()} is
      * never invoked.
      * </p>
      *
      * <p>
-     * <b>Important note:</b> All readFrameSlots that are give must be initialized before entering
-     * the loop. Also all writtenFrameSlots must be initialized inside of the loop if it was not
+     * <b>Important note:</b> All readFrameSlots that are given must be initialized before entering
+     * the loop. Also all writtenFrameSlots must be initialized inside of the loop if they were not
      * initialized outside the loop.
      * </p>
      *
@@ -326,17 +326,17 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
      * @param osrThreshold the threshold after how many loop iterations an OSR compilation is
      *            triggered. If the repeating node uses child loops or
      *            {@link LoopNode#reportLoopCount(Node, int)} then these iterations also contribute
-     *            to this loop iterations.
+     *            to this loop's iterations.
      * @param invalidationBackoff how many iterations the loop should get reprofiled until the next
      *            compile is scheduled.
      * @param readFrameSlots a set of all frame slots which are read inside the loop.
      *            <code>null</code> for unknown. All given frame slots must not have the
      *            {@link FrameSlotKind#Illegal illegal frame slot kind} set. If readFrameSlot is
-     *            kept <code>null</code> writtenFRameSlots must be <code>null</code> as well.
+     *            kept <code>null</code> writtenFrameSlots must be <code>null</code> as well.
      * @param writtenFrameSlots a set of all frame slots which are written inside the loop.
      *            <code>null</code> for unknown. All given frame slots must not have the
-     *            {@link FrameSlotKind#Illegal illegal frame slot kind} set.If readFrameSlot is kept
-     *            <code>null</code> writtenFRameSlots must be <code>null</code> as well.
+     *            {@link FrameSlotKind#Illegal illegal frame slot kind} set. If readFrameSlot is
+     *            kept <code>null</code> writtenFRameSlots must be <code>null</code> as well.
      *
      * @see LoopNode LoopNode on how to use loop nodes.
      */
@@ -452,21 +452,14 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
         @CompilationFinal private final FrameSlot[] readFrameSlots;
         @CompilationFinal private final FrameSlot[] writtenFrameSlots;
 
-        private final Class<? extends FrameWithoutBoxing> frameClass;
-        /* STores the */
         @CompilationFinal private final byte[] readFrameSlotsTags;
         @CompilationFinal private final byte[] writtenFrameSlotsTags;
         private final int maxTagsLength;
 
-        @SuppressWarnings("unchecked")
         VirtualizingOSRRootNode(VirtualizingOSRRootNode previousRoot, OptimizedOSRLoopNode loop, @SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage,
                         FrameDescriptor frameDescriptor,
                         Class<? extends VirtualFrame> clazz) {
             super(loop, truffleLanguage, frameDescriptor, clazz);
-            if (!clazz.isAssignableFrom(FrameWithoutBoxing.class)) {
-                throw new IllegalArgumentException("Unsupported frame type " + clazz.getName());
-            }
-            this.frameClass = (Class<? extends FrameWithoutBoxing>) clazz;
             this.readFrameSlots = previousRoot.readFrameSlots;
             this.writtenFrameSlots = previousRoot.writtenFrameSlots;
             this.readFrameSlotsTags = previousRoot.readFrameSlotsTags;
@@ -474,15 +467,10 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
             this.maxTagsLength = previousRoot.maxTagsLength;
         }
 
-        @SuppressWarnings("unchecked")
         VirtualizingOSRRootNode(OptimizedOSRLoopNode loop, @SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage, FrameDescriptor frameDescriptor,
                         Class<? extends VirtualFrame> clazz,
                         FrameSlot[] readFrameSlots, FrameSlot[] writtenFrameSlots) {
             super(loop, truffleLanguage, frameDescriptor, clazz);
-            if (!clazz.isAssignableFrom(FrameWithoutBoxing.class)) {
-                throw new IllegalArgumentException("Unsupported frame type " + clazz.getName());
-            }
-            this.frameClass = (Class<? extends FrameWithoutBoxing>) clazz;
             this.readFrameSlots = readFrameSlots;
             this.writtenFrameSlots = writtenFrameSlots;
             this.readFrameSlotsTags = new byte[readFrameSlots.length];
@@ -507,8 +495,8 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
 
         @Override
         protected Object executeImpl(VirtualFrame originalFrame) {
-            FrameWithoutBoxing loopFrame = frameClass.cast(originalFrame);
-            FrameWithoutBoxing parentFrame = frameClass.cast(loopFrame.getArguments()[0]);
+            FrameWithoutBoxing loopFrame = (FrameWithoutBoxing) (originalFrame);
+            FrameWithoutBoxing parentFrame = (FrameWithoutBoxing) (loopFrame.getArguments()[0]);
             executeTransfer(parentFrame, loopFrame, readFrameSlots, readFrameSlotsTags);
             try {
                 while (loopNode.getRepeatingNode().executeRepeating(loopFrame)) {
@@ -546,7 +534,7 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
                 byte speculatedTag = speculatedTags[i];
                 byte currentSourceTag = currentSourceTags[index];
                 if (CompilerDirectives.inInterpreter()) {
-                    if (currentSourceTag == 0) {
+                    if (currentSourceTag == 0 && speculatedTag != 0) {
                         if (frameSlots == readFrameSlots) {
                             throw new AssertionError("Frame slot " + slot + " was never writte outside the loop but virtualized as read frame slot.");
                         } else {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,39 +22,78 @@
  */
 package com.oracle.graal.truffle;
 
+import java.util.Objects;
+
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.ReplaceObserver;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RepeatingNode;
 import com.oracle.truffle.api.nodes.RootNode;
 
-public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObserver {
-
-    private CompilationProfile cachedProfile;
-    private int lastLoopCount;
-    private OptimizedCallTarget compiledTarget;
+/**
+ * Loop node implementation that supports on-stack-replacement with compiled code.
+ *
+ * @see #create(RepeatingNode)
+ * @see #createOSRLoop(RepeatingNode, int, int, FrameSlot[], FrameSlot[])
+ */
+public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceObserver {
 
     @Child private RepeatingNode repeatableNode;
 
-    private boolean disabled;
+    /*
+     * We disable profiling if its very unlikely that this loop is ever going to get OSR compiled.
+     * For example if the parent call target or a parent loop is already hot or compiling.
+     */
+    private boolean profilingEnabled = true;
 
-    private OptimizedOSRLoopNode(RepeatingNode repeatableNode) {
+    /*
+     * If an OSR compilation is scheduled the corresponding call target is stored here.
+     */
+    private OptimizedCallTarget compiledOSRLoop;
+
+    /*
+     * The current loop count. Not for condition probabilities use as it might stop profiling.
+     */
+    private int loopCount;
+    /*
+     * The current loop threshold. Might get increased with each invalidation.
+     */
+    private int osrThreshold;
+
+    private OptimizedOSRLoopNode(RepeatingNode repeatableNode, int osrThreshold) {
+        Objects.nonNull(repeatableNode);
+        if (osrThreshold < 0) {
+            throw new IllegalArgumentException("Invalid OSR threshold.");
+        }
         this.repeatableNode = repeatableNode;
+        this.osrThreshold = osrThreshold;
+    }
+
+    protected abstract int getInvalidationBackoff();
+
+    protected OSRRootNode createRootNode(@SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage, FrameDescriptor frameDescriptor,
+                    Class<? extends VirtualFrame> clazz) {
+        return new OSRRootNode(this, truffleLanguage, frameDescriptor, clazz);
     }
 
     @Override
-    public Node copy() {
+    public final Node copy() {
         OptimizedOSRLoopNode copy = (OptimizedOSRLoopNode) super.copy();
-        copy.compiledTarget = null;
+        copy.compiledOSRLoop = null;
         return copy;
     }
 
     @Override
-    public RepeatingNode getRepeatingNode() {
+    public final RepeatingNode getRepeatingNode() {
         return repeatableNode;
     }
 
@@ -63,7 +102,12 @@ public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObser
         if (CompilerDirectives.inInterpreter()) {
             boolean done = false;
             while (!done) {
-                if (compiledTarget == null) {
+                if (!profilingEnabled) {
+                    while (repeatableNode.executeRepeating(frame)) {
+                        // no OSR compilation can happen for this loop anymore.
+                    }
+                    break;
+                } else if (compiledOSRLoop == null) {
                     done = profilingLoop(frame);
                 } else {
                     done = compilingLoop(frame);
@@ -81,50 +125,56 @@ public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObser
     }
 
     private boolean profilingLoop(VirtualFrame frame) {
-        CompilationProfile profile = getProfile(getCallTarget());
-        int loopCount = 0;
-        boolean localDisabled = this.disabled;
+        int iterations = 0;
         try {
             while (repeatableNode.executeRepeating(frame)) {
-                loopCount++;
-                if (!localDisabled) {
-                    try {
-                        profile.reportOSR();
-                    } catch (ArithmeticException e) {
-                        compileLoop(frame);
-                        return false;
-                    }
+                iterations++;
+                int totalLoopCount = ++loopCount;
+                if (totalLoopCount > osrThreshold) {
+                    compileLoop(frame);
+                    return false;
                 }
             }
+            return true;
         } finally {
-            reportLoopCount(loopCount);
+            reportParentLoopCount(iterations);
         }
-        return true;
     }
 
-    private CompilationProfile getProfile(OptimizedCallTarget target) {
-        CompilationProfile profile = this.cachedProfile;
-        if (profile == null) {
-            profile = target.getCompilationProfile();
-            this.cachedProfile = profile;
+    private void reportParentLoopCount(int iterations) {
+        Node parent = getParent();
+        if (parent != null) {
+            LoopNode.reportLoopCount(parent, iterations);
         }
-        return profile;
     }
 
-    private OptimizedCallTarget getCallTarget() {
-        return (OptimizedCallTarget) getRootNode().getCallTarget();
+    final void reportChildLoopCount(int iterations) {
+        loopCount += iterations;
+    }
+
+    /**
+     * Forces OSR compilation for this loop.
+     */
+    public final void forceOSR() {
+        osrThreshold = loopCount;
+        RootNode rootNode = getRootNode();
+        VirtualFrame dummyFrame = Truffle.getRuntime().createVirtualFrame(new Object[0], rootNode != null ? rootNode.getFrameDescriptor() : new FrameDescriptor());
+        compileLoop(dummyFrame);
+    }
+
+    public final OptimizedCallTarget getCompiledOSRLoop() {
+        return compiledOSRLoop;
     }
 
     private boolean compilingLoop(VirtualFrame frame) {
         int iterations = 0;
         try {
             do {
-                OptimizedCallTarget target = compiledTarget;
+                OptimizedCallTarget target = compiledOSRLoop;
                 if (target == null) {
                     return false;
                 } else if (target.isValid()) {
-                    Object result = target.callDirect(new Object[]{frame});
-                    iterations = lastLoopCount;
+                    Object result = target.callDirect(frame);
                     if (result == Boolean.TRUE) {
                         // loop is done. No further repetitions necessary.
                         return true;
@@ -135,12 +185,15 @@ public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObser
                 } else if (!target.isCompiling()) {
                     invalidate(this, "OSR compilation failed or cancelled");
                     return false;
+                } else {
+                    iterations++;
+                    loopCount++;
                 }
             } while (repeatableNode.executeRepeating(frame));
+            return true;
         } finally {
-            reportLoopCount(iterations);
+            reportParentLoopCount(iterations);
         }
-        return true;
     }
 
     private void compileLoop(VirtualFrame frame) {
@@ -151,24 +204,32 @@ public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObser
                  * at the same time. This strategy lets the first thread win. Later threads will not
                  * issue compiles.
                  */
-                if (compiledTarget == null) {
-                    compiledTarget = compileImpl(frame);
+                if (compiledOSRLoop == null) {
+                    compiledOSRLoop = compileImpl(frame);
                 }
             }
         });
     }
 
-    private OptimizedCallTarget compileImpl(VirtualFrame frame) {
-        OptimizedCallTarget parentTarget = getCallTarget();
-        CompilationProfile profile = getProfile(parentTarget);
-        profile.reportOSRCompiledLoop();
-
-        if (parentTarget.isValid() || parentTarget.isCompiling()) {
-            disabled = true;
-            return null;
+    private OSRRootNode createRootNodeImpl(RootNode root, Class<? extends VirtualFrame> frameClass) {
+        @SuppressWarnings("rawtypes")
+        Class<? extends TruffleLanguage> truffleLanguage;
+        FrameDescriptor frameDescriptor;
+        if (root != null) {
+            truffleLanguage = OptimizedCallTarget.ACCESSOR.findLanguage(root);
+            frameDescriptor = root.getFrameDescriptor();
         } else {
+            truffleLanguage = TruffleLanguage.class;
+            frameDescriptor = new FrameDescriptor();
+        }
+        return createRootNode(truffleLanguage, frameDescriptor, frameClass);
+    }
+
+    private OptimizedCallTarget compileImpl(VirtualFrame frame) {
+        RootNode root = getRootNode();
+        if (shouldCompile(root)) {
             Node parent = getParent();
-            OptimizedCallTarget osrTarget = (OptimizedCallTarget) Truffle.getRuntime().createCallTarget(new OSRRootNode(this, frame.getClass()));
+            OptimizedCallTarget osrTarget = (OptimizedCallTarget) Truffle.getRuntime().createCallTarget(createRootNodeImpl(root, frame.getClass()));
             // to avoid a deopt on first call we provide some profiling information
             osrTarget.profileReturnType(Boolean.TRUE);
             osrTarget.profileReturnType(Boolean.FALSE);
@@ -177,51 +238,190 @@ public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObser
             parent.adoptChildren();
             osrTarget.compile();
             return osrTarget;
+        } else {
+            return null;
         }
     }
 
-    private void reportLoopCount(int reportIterations) {
-        if (reportIterations != 0) {
-            lastLoopCount = reportIterations;
-            getRootNode().reportLoopCount(reportIterations);
+    private boolean shouldCompile(RootNode root) {
+        OptimizedCallTarget parentTarget = root != null ? (OptimizedCallTarget) root.getCallTarget() : null;
+        if (parentTarget != null) {
+            if (parentTarget.isCompiling() ||
+                            parentTarget.isValid()) {
+                // no profiling anymore parent is already compiling.
+                profilingEnabled = false;
+                return false;
+            }
+
+            if (parentTarget.getCompilationProfile().getInterpreterCallCount() > TruffleCompilerOptions.TruffleMinInvokeThreshold.getValue()) {
+                // do not yet disable profiling
+                return false;
+            }
         }
+
+        Node node = getParent();
+        while (node != null) {
+            if (node instanceof OptimizedOSRLoopNode) {
+                OptimizedCallTarget target = ((OptimizedOSRLoopNode) node).getCompiledOSRLoop();
+                if (target != null) {
+                    // parent loop node is already compiling
+                    return false;
+                }
+            }
+            node = node.getParent();
+        }
+        return true;
     }
 
-    public boolean nodeReplaced(Node oldNode, Node newNode, CharSequence reason) {
+    public final boolean nodeReplaced(Node oldNode, Node newNode, CharSequence reason) {
         invalidate(newNode, reason);
         return false;
     }
 
     private void invalidate(Object source, CharSequence reason) {
-        OptimizedCallTarget target = this.compiledTarget;
+        OptimizedCallTarget target = this.compiledOSRLoop;
         if (target != null) {
+            int invalidationBackoff = getInvalidationBackoff();
+            if (invalidationBackoff < 0) {
+                throw new IllegalArgumentException("Invalid OSR invalidation backoff.");
+            }
+            osrThreshold = loopCount + invalidationBackoff;
+            compiledOSRLoop = null;
             target.invalidate(source, reason);
-            compiledTarget = null;
         }
     }
 
+    /**
+     * Creates the default loop node implementation with the default configuration. If OSR is
+     * disabled {@link OptimizedLoopNode} will be used instead.
+     */
     public static LoopNode create(RepeatingNode repeat) {
+        // using static methods with LoopNode return type ensures
+        // that only one loop node implementation gets loaded.
         if (TruffleCompilerOptions.TruffleOSR.getValue()) {
-            return new OptimizedOSRLoopNode(repeat);
+            return createDefault(repeat);
         } else {
-            return new OptimizedLoopNode(repeat);
+            return OptimizedLoopNode.create(repeat);
         }
     }
 
-    private static class OSRRootNode extends RootNode {
+    private static LoopNode createDefault(RepeatingNode repeatableNode) {
+        return new OptimizedDefaultOSRLoopNode(repeatableNode, TruffleCompilerOptions.TruffleOSRCompilationThreshold.getValue());
+    }
 
-        private final Class<? extends VirtualFrame> clazz;
+    /**
+     * <p>
+     * Creates a configurable instance of the OSR loop node. If readFrameSlots and writtenFrameSlots
+     * is set then the involved frame must never escape, ie {@link VirtualFrame#materialize()} is
+     * never invoked.
+     * </p>
+     *
+     * <p>
+     * <b>Important note:</b> All readFrameSlots that are give must be initialized before entering
+     * the loop. Also all writtenFrameSlots must be initialized inside of the loop if it was not
+     * initialized outside the loop.
+     * </p>
+     *
+     * @param repeating the repeating node to use for this loop.
+     * @param osrThreshold the threshold after how many loop iterations an OSR compilation is
+     *            triggered. If the repeating node uses child loops or
+     *            {@link LoopNode#reportLoopCount(Node, int)} then these iterations also contribute
+     *            to this loop iterations.
+     * @param invalidationBackoff how many iterations the loop should get reprofiled until the next
+     *            compile is scheduled.
+     * @param readFrameSlots a set of all frame slots which are read inside the loop.
+     *            <code>null</code> for unknown. All given frame slots must not have the
+     *            {@link FrameSlotKind#Illegal illegal frame slot kind} set. If readFrameSlot is
+     *            kept <code>null</code> writtenFRameSlots must be <code>null</code> as well.
+     * @param writtenFrameSlots a set of all frame slots which are written inside the loop.
+     *            <code>null</code> for unknown. All given frame slots must not have the
+     *            {@link FrameSlotKind#Illegal illegal frame slot kind} set.If readFrameSlot is kept
+     *            <code>null</code> writtenFRameSlots must be <code>null</code> as well.
+     *
+     * @see LoopNode LoopNode on how to use loop nodes.
+     */
+    public static OptimizedOSRLoopNode createOSRLoop(RepeatingNode repeating, int osrThreshold, int invalidationBackoff, FrameSlot[] readFrameSlots, FrameSlot[] writtenFrameSlots) {
+        if ((readFrameSlots == null) != (writtenFrameSlots == null)) {
+            throw new IllegalArgumentException("If either readFrameSlots or writtenFrameSlots is set both must be provided.");
+        }
+        return new OptimizedVirtualizingOSRLoopNode(repeating, osrThreshold, invalidationBackoff, readFrameSlots, writtenFrameSlots);
+    }
 
-        @Child private OptimizedOSRLoopNode loopNode;
+    /**
+     * Used by default in guest languages.
+     */
+    private static final class OptimizedDefaultOSRLoopNode extends OptimizedOSRLoopNode {
 
-        OSRRootNode(OptimizedOSRLoopNode loop, Class<? extends VirtualFrame> clazz) {
-            super(TruffleLanguage.class, loop.getSourceSection(), loop.getRootNode().getFrameDescriptor());
+        public OptimizedDefaultOSRLoopNode(RepeatingNode repeatableNode, int osrThreshold) {
+            super(repeatableNode, osrThreshold);
+        }
+
+        @Override
+        protected int getInvalidationBackoff() {
+            return TruffleCompilerOptions.TruffleInvalidationReprofileCount.getValue();
+        }
+
+    }
+
+    /**
+     * Used in guest languages with Graal runtime access that require more revirtualization of local
+     * variables and more configuration options.
+     */
+    private static class OptimizedVirtualizingOSRLoopNode extends OptimizedOSRLoopNode {
+
+        private final int invalidationBackoff;
+        @CompilationFinal private final FrameSlot[] readFrameSlots;
+        @CompilationFinal private final FrameSlot[] writtenFrameSlots;
+
+        private VirtualizingOSRRootNode previousRoot;
+
+        private OptimizedVirtualizingOSRLoopNode(RepeatingNode repeatableNode, int osrThreshold, int invalidationBackoff, FrameSlot[] readFrameSlots, FrameSlot[] writtenFrameSlots) {
+            super(repeatableNode, osrThreshold);
+            this.invalidationBackoff = invalidationBackoff;
+            this.readFrameSlots = readFrameSlots;
+            this.writtenFrameSlots = writtenFrameSlots;
+        }
+
+        @Override
+        public int getInvalidationBackoff() {
+            return invalidationBackoff;
+        }
+
+        @Override
+        protected OSRRootNode createRootNode(@SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage, FrameDescriptor frameDescriptor, Class<? extends VirtualFrame> clazz) {
+            if (readFrameSlots == null || writtenFrameSlots == null) {
+                return super.createRootNode(truffleLanguage, frameDescriptor, clazz);
+            } else {
+                if (previousRoot == null) {
+                    previousRoot = new VirtualizingOSRRootNode(this, truffleLanguage, frameDescriptor, clazz, readFrameSlots, writtenFrameSlots);
+                } else {
+                    // we want to reuse speculations from a previous compilation so no rewrite loops
+                    // occur.
+                    previousRoot = new VirtualizingOSRRootNode(previousRoot, this, truffleLanguage, frameDescriptor, clazz);
+                }
+                return previousRoot;
+            }
+        }
+
+    }
+
+    public static class OSRRootNode extends RootNode {
+
+        protected final Class<? extends VirtualFrame> clazz;
+
+        @Child protected OptimizedOSRLoopNode loopNode;
+
+        OSRRootNode(OptimizedOSRLoopNode loop, @SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage, FrameDescriptor frameDescriptor, Class<? extends VirtualFrame> clazz) {
+            super(truffleLanguage, loop.getSourceSection(), frameDescriptor);
             this.loopNode = loop;
             this.clazz = clazz;
         }
 
-        @Override
-        public Object execute(VirtualFrame frame) {
+        public static Object callProxy(OSRRootNode target, VirtualFrame frame) {
+            return target.executeImpl(frame);
+        }
+
+        protected Object executeImpl(VirtualFrame frame) {
             VirtualFrame parentFrame = clazz.cast(frame.getArguments()[0]);
             while (loopNode.getRepeatingNode().executeRepeating(parentFrame)) {
                 if (CompilerDirectives.inInterpreter()) {
@@ -232,15 +432,164 @@ public final class OptimizedOSRLoopNode extends LoopNode implements ReplaceObser
         }
 
         @Override
-        public boolean isCloningAllowed() {
+        public final Object execute(VirtualFrame frame) {
+            return callProxy(this, frame);
+        }
+
+        @Override
+        public final boolean isCloningAllowed() {
             return false;
         }
 
         @Override
-        public String toString() {
+        public final String toString() {
             return loopNode.getRepeatingNode().toString() + "<OSR>";
+        }
+    }
+
+    private static final class VirtualizingOSRRootNode extends OSRRootNode {
+
+        @CompilationFinal private final FrameSlot[] readFrameSlots;
+        @CompilationFinal private final FrameSlot[] writtenFrameSlots;
+
+        private final Class<? extends FrameWithoutBoxing> frameClass;
+        /* STores the */
+        @CompilationFinal private final byte[] readFrameSlotsTags;
+        @CompilationFinal private final byte[] writtenFrameSlotsTags;
+        private final int maxTagsLength;
+
+        @SuppressWarnings("unchecked")
+        VirtualizingOSRRootNode(VirtualizingOSRRootNode previousRoot, OptimizedOSRLoopNode loop, @SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage,
+                        FrameDescriptor frameDescriptor,
+                        Class<? extends VirtualFrame> clazz) {
+            super(loop, truffleLanguage, frameDescriptor, clazz);
+            if (!clazz.isAssignableFrom(FrameWithoutBoxing.class)) {
+                throw new IllegalArgumentException("Unsupported frame type " + clazz.getName());
+            }
+            this.frameClass = (Class<? extends FrameWithoutBoxing>) clazz;
+            this.readFrameSlots = previousRoot.readFrameSlots;
+            this.writtenFrameSlots = previousRoot.writtenFrameSlots;
+            this.readFrameSlotsTags = previousRoot.readFrameSlotsTags;
+            this.writtenFrameSlotsTags = previousRoot.writtenFrameSlotsTags;
+            this.maxTagsLength = previousRoot.maxTagsLength;
+        }
+
+        @SuppressWarnings("unchecked")
+        VirtualizingOSRRootNode(OptimizedOSRLoopNode loop, @SuppressWarnings("rawtypes") Class<? extends TruffleLanguage> truffleLanguage, FrameDescriptor frameDescriptor,
+                        Class<? extends VirtualFrame> clazz,
+                        FrameSlot[] readFrameSlots, FrameSlot[] writtenFrameSlots) {
+            super(loop, truffleLanguage, frameDescriptor, clazz);
+            if (!clazz.isAssignableFrom(FrameWithoutBoxing.class)) {
+                throw new IllegalArgumentException("Unsupported frame type " + clazz.getName());
+            }
+            this.frameClass = (Class<? extends FrameWithoutBoxing>) clazz;
+            this.readFrameSlots = readFrameSlots;
+            this.writtenFrameSlots = writtenFrameSlots;
+            this.readFrameSlotsTags = new byte[readFrameSlots.length];
+            this.writtenFrameSlotsTags = new byte[writtenFrameSlots.length];
+            int maxIndex = -1;
+            maxIndex = initializeFrameSlots(readFrameSlots, readFrameSlotsTags, maxIndex);
+            maxIndex = initializeFrameSlots(writtenFrameSlots, writtenFrameSlotsTags, maxIndex);
+            this.maxTagsLength = maxIndex + 1;
+        }
+
+        private static int initializeFrameSlots(FrameSlot[] frameSlots, byte[] tags, int maxIndex) {
+            int currentMaxIndex = maxIndex;
+            for (int i = 0; i < frameSlots.length; i++) {
+                FrameSlot frameSlot = frameSlots[i];
+                if (frameSlot.getIndex() > currentMaxIndex) {
+                    currentMaxIndex = frameSlot.getIndex();
+                }
+                tags[i] = frameSlot.getKind().tag;
+            }
+            return currentMaxIndex;
+        }
+
+        @Override
+        protected Object executeImpl(VirtualFrame originalFrame) {
+            FrameWithoutBoxing loopFrame = frameClass.cast(originalFrame);
+            FrameWithoutBoxing parentFrame = frameClass.cast(loopFrame.getArguments()[0]);
+            executeTransfer(parentFrame, loopFrame, readFrameSlots, readFrameSlotsTags);
+            try {
+                while (loopNode.getRepeatingNode().executeRepeating(loopFrame)) {
+                    if (CompilerDirectives.inInterpreter()) {
+                        return Boolean.FALSE;
+                    }
+                }
+                return Boolean.TRUE;
+            } finally {
+                executeTransfer(loopFrame, parentFrame, writtenFrameSlots, writtenFrameSlotsTags);
+            }
+        }
+
+        @ExplodeLoop
+        private void executeTransfer(FrameWithoutBoxing source, FrameWithoutBoxing target, FrameSlot[] frameSlots, byte[] speculatedTags) {
+            if (frameSlots == null) {
+                return;
+            }
+            byte[] currentSourceTags = source.getTags();
+            byte[] currentTargetTags = target.getTags();
+
+            /*
+             * We check max tags so length of the tags array is not checked inside the loop each
+             * time.
+             */
+            if (currentSourceTags.length < maxTagsLength || currentTargetTags.length < maxTagsLength) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                throw new AssertionError("Frames should never shrink.");
+            }
+
+            for (int i = 0; i < frameSlots.length; i++) {
+                FrameSlot slot = frameSlots[i];
+                int index = slot.getIndex();
+
+                byte speculatedTag = speculatedTags[i];
+                byte currentSourceTag = currentSourceTags[index];
+                if (CompilerDirectives.inInterpreter()) {
+                    if (currentSourceTag == 0) {
+                        if (frameSlots == readFrameSlots) {
+                            throw new AssertionError("Frame slot " + slot + " was never writte outside the loop but virtualized as read frame slot.");
+                        } else {
+                            throw new AssertionError("Frame slot " + slot + " was never written in the loop but virtualized as written frame slot.");
+                        }
+                    }
+                }
+
+                boolean tagsCondition = speculatedTag == currentSourceTag;
+                if (!tagsCondition) {
+                    CompilerDirectives.transferToInterpreterAndInvalidate();
+                    speculatedTags[i] = currentSourceTag;
+                    speculatedTag = currentSourceTag;
+                }
+
+                switch (speculatedTag) {
+                    case FrameWithoutBoxing.BOOLEAN_TAG:
+                        target.setBoolean(slot, source.getBooleanUnsafe(index, slot, tagsCondition));
+                        break;
+                    case FrameWithoutBoxing.BYTE_TAG:
+                        target.setByte(slot, source.getByteUnsafe(index, slot, tagsCondition));
+                        break;
+                    case FrameWithoutBoxing.DOUBLE_TAG:
+                        target.setDouble(slot, source.getDoubleUnsafe(index, slot, tagsCondition));
+                        break;
+                    case FrameWithoutBoxing.FLOAT_TAG:
+                        target.setFloat(slot, source.getFloatUnsafe(index, slot, tagsCondition));
+                        break;
+                    case FrameWithoutBoxing.INT_TAG:
+                        target.setInt(slot, source.getIntUnsafe(index, slot, tagsCondition));
+                        break;
+                    case FrameWithoutBoxing.LONG_TAG:
+                        target.setLong(slot, source.getLongUnsafe(index, slot, tagsCondition));
+                        break;
+                    case FrameWithoutBoxing.OBJECT_TAG:
+                        target.setObject(slot, source.getObjectUnsafe(index, slot, tagsCondition));
+                        break;
+                    default:
+                        CompilerDirectives.transferToInterpreterAndInvalidate();
+                        throw new AssertionError("Defined frame slot " + slot + " is illegal. Revirtualization failed. Please initialize frame slot with a FrameSlotKind.");
+                }
+            }
         }
 
     }
-
 }

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -47,7 +47,7 @@ suite = {
             },
             {
                "name" : "truffle",
-               "version" : "e23ee999366fa8ecd6012422965ca4e295fc76ac",
+               "version" : "f322868c76f775a399bf96915c95e077c4f2c08c",
                "urls" : [
                     {"url" : "https://github.com/graalvm/truffle.git", "kind" : "git"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -47,7 +47,7 @@ suite = {
             },
             {
                "name" : "truffle",
-               "version" : "7de96d3ba72f2d1a2a0ef39351a3db4764c74b9c",
+               "version" : "4b0efa45c16febf1b77656d67bf9914c23256e84",
                "urls" : [
                     {"url" : "https://github.com/graalvm/truffle.git", "kind" : "git"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -47,7 +47,7 @@ suite = {
             },
             {
                "name" : "truffle",
-               "version" : "4b0efa45c16febf1b77656d67bf9914c23256e84",
+               "version" : "e23ee999366fa8ecd6012422965ca4e295fc76ac",
                "urls" : [
                     {"url" : "https://github.com/graalvm/truffle.git", "kind" : "git"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
Cleanup and refactor OSR; 
Move to local counters instead of a global counter in CallTarget; 
Implemented revirtualization of local variables usable by internal API. 
Added OSR test suite.

This is quite a serious change of the OSR mechanism.
@woess  please review and verify that it works with JS
@chrisseaton please verify that this works Ruby

Please note that the default OSR threshold is quite high atm.

I will verify/verified it for Fastr (cc @lukasstadler).
