### PR TITLE
Cleanup branch instrumentation.

### DIFF
--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleCompiler.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleCompiler.java
@@ -89,10 +89,13 @@ public final class DefaultTruffleCompiler extends TruffleCompiler {
         }
 
         public static class Instance extends GraphBuilderPhase.Instance {
+            private boolean mustInstrumentBranches;
+
             public Instance(MetaAccessProvider metaAccess, StampProvider stampProvider,
                             ConstantReflectionProvider constantReflection, GraphBuilderConfiguration config,
                             OptimisticOptimizations optimisticOpts, IntrinsicContext initialIntrinsicContext) {
                 super(metaAccess, stampProvider, constantReflection, config, optimisticOpts, initialIntrinsicContext);
+                this.mustInstrumentBranches = TruffleCompilerOptions.TruffleInstrumentBranches.getValue();
             }
 
             @Override
@@ -107,7 +110,7 @@ public final class DefaultTruffleCompiler extends TruffleCompiler {
                 return new BytecodeParser(this, graph, parent, method, entryBCI, intrinsicContext) {
                     @Override
                     protected void postProcessIfNode(ValueNode node) {
-                        if (TruffleCompilerOptions.TruffleInstrumentBranches.getValue()) {
+                        if (mustInstrumentBranches) {
                             InstrumentBranchesPhase.addNodeSourceLocation(node, createBytecodePosition());
                         }
                     }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/phases/InstrumentBranchesPhase.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/phases/InstrumentBranchesPhase.java
@@ -24,6 +24,7 @@ package com.oracle.graal.truffle.phases;
 
 import com.oracle.graal.compiler.common.type.StampFactory;
 import com.oracle.graal.compiler.common.type.TypeReference;
+import com.oracle.graal.debug.TTY;
 import com.oracle.graal.graph.Node;
 import com.oracle.graal.nodes.AbstractBeginNode;
 import com.oracle.graal.nodes.ConstantNode;
@@ -156,7 +157,10 @@ public class InstrumentBranchesPhase extends BasePhase<HighTierContext> {
                 pointMap.put(key, p);
                 return p;
             } else {
-                System.err.println("Maximum number of branch instrumentation counters exceeded.");
+                if (tableCount == ACCESS_TABLE.length) {
+                    TTY.println("Maximum number of branch instrumentation counters exceeded.");
+                    tableCount += 1;
+                }
                 return null;
             }
         }


### PR DESCRIPTION
Use `TTY` to print the "branch instrumentation count exceeded" warning,
and print the warning only once.
Avoid rechecking the same flag multiple times.

Review by @woess 