### PR TITLE
Enable TruffleCompilationExceptionsAreFatal when asserts are enabled.

### DIFF
--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
@@ -397,9 +397,16 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
             if (TruffleCompilationExceptionsAreThrown.getValue()) {
                 throw new OptimizationFailedException(t, this);
             }
-            if (TruffleCompilationExceptionsArePrinted.getValue() || TruffleCompilationExceptionsAreFatal.getValue()) {
+            /*
+             * Automatically enable TruffleCompilationExceptionsAreFatal when asserts are enabled
+             * but respect TruffleCompilationExceptionsAreFatal if it's been explicitly set.
+             */
+            boolean truffleCompilationExceptionsAreFatal = TruffleCompilationExceptionsAreFatal.getValue();
+            assert TruffleCompilationExceptionsAreFatal.hasBeenSet() || (truffleCompilationExceptionsAreFatal = true) == true;
+
+            if (TruffleCompilationExceptionsArePrinted.getValue() || truffleCompilationExceptionsAreFatal) {
                 printException(t);
-                if (TruffleCompilationExceptionsAreFatal.getValue()) {
+                if (truffleCompilationExceptionsAreFatal) {
                     System.exit(-1);
                 }
             }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/TruffleCompilerOptions.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/TruffleCompilerOptions.java
@@ -136,7 +136,7 @@ public class TruffleCompilerOptions {
     public static final OptionValue<Boolean> TruffleCompilationExceptionsAreFatal = new OptionValue<>(false);
 
     @Option(help = "Prints the exception stack trace for compilation exceptions", type = OptionType.Debug)
-    public static final OptionValue<Boolean> TruffleCompilationExceptionsArePrinted = new OptionValue<>(false);
+    public static final OptionValue<Boolean> TruffleCompilationExceptionsArePrinted = new OptionValue<>(true);
 
     @Option(help = "Treat compilation exceptions as thrown runtime exceptions", type = OptionType.Debug)
     public static final OptionValue<Boolean> TruffleCompilationExceptionsAreThrown = new OptionValue<>(false);

--- a/mx.graal-core/mx_graal_8.py
+++ b/mx.graal-core/mx_graal_8.py
@@ -315,7 +315,7 @@ def compiler_gate_runner(suites, unit_test_runs, bootstrap_tests, tasks, extraVM
 
 
 graal_unit_test_runs = [
-    UnitTestRun('UnitTests', ['-G:+TruffleCompilationExceptionsAreFatal'], tags=[GraalTags.test]),
+    UnitTestRun('UnitTests', [], tags=[GraalTags.test]),
 ]
 
 _registers = 'o0,o1,o2,o3,f8,f9,d32,d34' if mx.get_arch() == 'sparcv9' else 'rbx,r11,r10,r14,xmm3,xmm11,xmm14'

--- a/mx.graal-core/mx_graal_9.py
+++ b/mx.graal-core/mx_graal_9.py
@@ -288,7 +288,7 @@ def compiler_gate_runner(suites, unit_test_runs, bootstrap_tests, tasks, extraVM
 
 
 graal_unit_test_runs = [
-    UnitTestRun('UnitTests', ['-G:+TruffleCompilationExceptionsAreFatal'], tags=[GraalTags.test]),
+    UnitTestRun('UnitTests', [], tags=[GraalTags.test]),
 ]
 
 _registers = 'o0,o1,o2,o3,f8,f9,d32,d34' if mx.get_arch() == 'sparcv9' else 'rbx,r11,r10,r14,xmm3,xmm11,xmm14'


### PR DESCRIPTION
Same idea as #82 but for `TruffleCompilationExceptionsAreFatal`. I'm not completely sure about the downstream implications so reviews from Truffle folks would be great, maybe @woess @chumer @chrisseaton?

Note that this supersedes #109.