### PR TITLE
Correctly check for progress when removing phi from list during peel

### DIFF
--- a/graal/com.oracle.graal.loop/src/com/oracle/graal/loop/LoopFragmentInside.java
+++ b/graal/com.oracle.graal.loop/src/com/oracle/graal/loop/LoopFragmentInside.java
@@ -276,11 +276,11 @@ public class LoopFragmentInside extends LoopFragment {
             }
         }
 
-        int oldPhisSize;
-        do {
-            oldPhisSize = oldPhis.size();
+        boolean progress = true;
+        while (progress) {
+            progress = false;
             int i = 0;
-            outer: while (i < oldPhisSize) {
+            outer: while (i < oldPhis.size()) {
                 PhiNode oldPhi = oldPhis.get(i);
                 for (Node usage : oldPhi.usages()) {
                     if (usage instanceof PhiNode && oldPhis.contains(usage)) {
@@ -288,14 +288,13 @@ public class LoopFragmentInside extends LoopFragment {
                     } else {
                         // Mark alive by removing from delete set.
                         oldPhis.remove(i);
-                        oldPhisSize--;
+                        progress = true;
                         continue outer;
                     }
                 }
                 i++;
             }
-            // Check for progress.
-        } while (oldPhisSize != oldPhis.size());
+        }
 
         for (PhiNode deadPhi : oldPhis) {
             deadPhi.clearInputs();


### PR DESCRIPTION
Removing the element from the list changes the progress conditions so the previous fix in #114 will only go through the list once.  Use a progress flag instead.