### PR TITLE
Try to fix WriteBarrierAdditionTest on JDK9

### DIFF
--- a/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/WriteBarrierAdditionTest.java
+++ b/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/WriteBarrierAdditionTest.java
@@ -147,6 +147,8 @@ public class WriteBarrierAdditionTest extends HotSpotGraalCompilerTest {
      */
     @Test
     public void test4() throws Exception {
+        // Exercise the snippet before compiling it to ensure that everything is resolved.
+        test4Snippet();
         testHelper("test4Snippet", config.useG1GC ? 5 : 2);
     }
 


### PR DESCRIPTION
The debug output I added finally triggered and it looks like we're terminating the parse with a deopt so we have fewer than expected barriers.  From https://travis-ci.org/graalvm/graal-core/builds/115086162

 `0|StartNode    (0)`
  `1|NewInstanceNode    (4)`
  `2|NewInstanceNode    (3)`
 ` 3|CompressionNode    (2)`
  `4|OffsetAddressNode    (3)`
 ` 5|G1PreWriteBarrier    (0)`
  `6|WriteNode    (0)`
 ` 7|G1PostWriteBarrier    (0)`
  `8|DeoptimizeNode    (0)`
 `expected:<5> but was:<2>`

It looks like we're deoptimizing before the get call.  It's possible this code hasn't been exercised at the point we compile it.  I've added an invoke of the method to ensure everything has been resolved but I we won't really know for it's fixed.