### PR TITLE
OptimizedCallTarget: add JavaDoc to avoid warning.

### DIFF
--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
@@ -490,6 +490,9 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         return castArguments;
     }
 
+    /**
+     * @param length avoid warning
+     */
     private static Object castArrayFixedLength(Object[] args, int length) {
         return args;
     }
@@ -606,6 +609,11 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         return DefaultCompilerOptions.INSTANCE;
     }
 
+    /**
+     * @param type avoid warning
+     * @param condition avoid warning
+     * @param nonNull avoid warning
+     */
     @SuppressWarnings({"unchecked"})
     private static <T> T unsafeCast(Object value, Class<T> type, boolean condition, boolean nonNull) {
         return (T) value;


### PR DESCRIPTION
Fix warnings in Eclipse Mars introduced #100.