### PR TITLE
TraceRA: fix block printing for trace interval dumps.

### DIFF
--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanLifetimeAnalysisPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanLifetimeAnalysisPhase.java
@@ -98,8 +98,8 @@ final class TraceLinearScanLifetimeAnalysisPhase extends TraceLinearScanAllocati
 
         private void analyze() {
             countInstructions();
-            allocator.printLir("Before register allocation", true);
             buildIntervals();
+            allocator.printLir("Before register allocation", true);
         }
 
         private boolean sameTrace(AbstractBlockBase<?> a, AbstractBlockBase<?> b) {


### PR DESCRIPTION
In #98 we switched to lazy instruction numbering during interval building which is a problem for c1visualizer since it needs instruction numbers to draw block boundaries in the interval view. So solve this we dump the LIR after interval building.