### PR TITLE
PE: @ExplodeLoop(merge=false) should use LoopExplosionKind.FULL_UNROLL

### DIFF
--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/SimplifyingGraphDecoder.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/SimplifyingGraphDecoder.java
@@ -199,18 +199,18 @@ public class SimplifyingGraphDecoder extends GraphDecoder {
                      */
                     canonical = new CanonicalizeToNullNode(node.stamp);
                 }
-                handleCanonicaliation(methodScope, loopScope, nodeOrderId, node, canonical);
+                handleCanonicalization(methodScope, loopScope, nodeOrderId, node, canonical);
             }
 
         } else if (node instanceof Canonicalizable) {
             Node canonical = ((Canonicalizable) node).canonical(new PECanonicalizerTool());
             if (canonical != node) {
-                handleCanonicaliation(methodScope, loopScope, nodeOrderId, node, canonical);
+                handleCanonicalization(methodScope, loopScope, nodeOrderId, node, canonical);
             }
         }
     }
 
-    private void handleCanonicaliation(MethodScope methodScope, LoopScope loopScope, int nodeOrderId, FixedNode node, Node c) {
+    private void handleCanonicalization(MethodScope methodScope, LoopScope loopScope, int nodeOrderId, FixedNode node, Node c) {
         Node canonical = c;
 
         if (canonical == null) {

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
@@ -348,7 +348,7 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         } else if (loopExplosionPlugin.shouldMergeExplosions(method)) {
             return LoopExplosionKind.MERGE_EXPLODE;
         } else if (loopExplosionPlugin.shouldExplodeLoops(method)) {
-            return LoopExplosionKind.FULL_EXPLODE;
+            return LoopExplosionKind.FULL_UNROLL;
         } else {
             return LoopExplosionKind.NONE;
         }

--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/SimplePartialEvaluationTest.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/SimplePartialEvaluationTest.java
@@ -112,7 +112,7 @@ public class SimplePartialEvaluationTest extends PartialEvaluationTest {
     public void twoMergesLoopExplosion() {
         FrameDescriptor fd = new FrameDescriptor();
         AbstractTestNode result = new AddTestNode(new TwoMergesExplodedLoopTestNode(5), new ConstantTestNode(37));
-        assertPartialEvalEquals("constant42", new RootTestNode(fd, "nestedLoopExplosion", result));
+        assertPartialEvalEquals("constant42", new RootTestNode(fd, "twoMergesLoopExplosion", result));
     }
 
     @Test

--- a/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/nodes/TwoMergesExplodedLoopTestNode.java
+++ b/graal/com.oracle.graal.truffle.test/src/com/oracle/graal/truffle/test/nodes/TwoMergesExplodedLoopTestNode.java
@@ -40,7 +40,7 @@ public class TwoMergesExplodedLoopTestNode extends AbstractTestNode {
         this.count = count;
     }
 
-    @ExplodeLoop(merge = false)
+    @ExplodeLoop(merge = true)
     @Override
     public int execute(VirtualFrame frame) {
         Flag flag = new Flag();


### PR DESCRIPTION
This affects, e.g., code of the form:
```java
@ExplodeLoop
public void executeVoid(VirtualFrame frame) {
    int n = statements.length;
    for (int i = 0; i < n; i++) {
        if (/* some condition */) {
            statements[i].executeVoid(frame);
        }
    }
}
```
Graal simplifies the Merge |> LoopEnd to 2 LoopEnds and this leads to an exponential number of exploded loop iterations with `LoopExplosionKind.FULL_EXPLODE`.
I don't think this behavior is intentional or desired. So the solution is to change it to `FULL_UNROLL`, which is what I would expect to happen here (i.e., loop unrolled `n` times).
Please let me know if you do have a case where you really want the full explosion.