### PR TITLE
TraceRA: outsource tracebuilding

### DIFF
--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceBuilderPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceBuilderPhase.java
@@ -35,14 +35,14 @@ import com.oracle.graal.compiler.common.cfg.AbstractBlockBase;
 import com.oracle.graal.debug.Debug;
 import com.oracle.graal.lir.LIR;
 import com.oracle.graal.lir.gen.LIRGenerationResult;
-import com.oracle.graal.lir.phases.LIRPhase;
+import com.oracle.graal.lir.phases.AllocationPhase;
 import com.oracle.graal.options.Option;
 import com.oracle.graal.options.OptionType;
 import com.oracle.graal.options.OptionValue;
 
 import jdk.vm.ci.code.TargetDescription;
 
-public class TraceBuilderPhase extends LIRPhase<TraceBuilderPhase.TraceBuilderContext> {
+public class TraceBuilderPhase extends AllocationPhase {
 
     public static class Options {
         // @formatter:off
@@ -51,15 +51,11 @@ public class TraceBuilderPhase extends LIRPhase<TraceBuilderPhase.TraceBuilderCo
         // @formatter:on
     }
 
-    public static final class TraceBuilderContext {
-        public TraceBuilderResult<?> traceBuilderResult;
-
-    }
-
     private static final int TRACE_LOG_LEVEL = 1;
+    public static final int TRACE_DUMP_LEVEL = 3;
 
     @Override
-    protected <B extends AbstractBlockBase<B>> void run(TargetDescription target, LIRGenerationResult lirGenRes, List<B> codeEmittingOrder, List<B> linearScanOrder, TraceBuilderContext context) {
+    protected <B extends AbstractBlockBase<B>> void run(TargetDescription target, LIRGenerationResult lirGenRes, List<B> codeEmittingOrder, List<B> linearScanOrder, AllocationContext context) {
         B startBlock = linearScanOrder.get(0);
         LIR lir = lirGenRes.getLIR();
         assert startBlock.equals(lir.getControlFlowGraph().getStartBlock());
@@ -78,7 +74,8 @@ public class TraceBuilderPhase extends LIRPhase<TraceBuilderPhase.TraceBuilderCo
             }
         }
         TraceStatisticsPrinter.printTraceStatistics(traceBuilderResult, lirGenRes.getCompilationUnitName());
-        context.traceBuilderResult = traceBuilderResult;
+        Debug.dump(TRACE_DUMP_LEVEL, traceBuilderResult, "After TraceBuilding");
+        context.contextAdd(traceBuilderResult);
     }
 
 }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
@@ -22,13 +22,14 @@
  */
 package com.oracle.graal.lir.alloc.trace;
 
+import static com.oracle.graal.lir.alloc.trace.TraceUtil.isTrivialTrace;
+
 import java.util.Collection;
 import java.util.List;
 
 import com.oracle.graal.compiler.common.alloc.RegisterAllocationConfig;
 import com.oracle.graal.compiler.common.alloc.Trace;
 import com.oracle.graal.compiler.common.alloc.TraceBuilderResult;
-import com.oracle.graal.compiler.common.alloc.TraceStatisticsPrinter;
 import com.oracle.graal.compiler.common.cfg.AbstractBlockBase;
 import com.oracle.graal.debug.Debug;
 import com.oracle.graal.debug.Debug.Scope;
@@ -36,8 +37,6 @@ import com.oracle.graal.debug.DebugMetric;
 import com.oracle.graal.debug.Indent;
 import com.oracle.graal.lir.LIR;
 import com.oracle.graal.lir.LIRInstruction;
-import com.oracle.graal.lir.StandardOp.JumpOp;
-import com.oracle.graal.lir.StandardOp.LabelOp;
 import com.oracle.graal.lir.alloc.trace.TraceAllocationPhase.TraceAllocationContext;
 import com.oracle.graal.lir.alloc.trace.TraceBuilderPhase.TraceBuilderContext;
 import com.oracle.graal.lir.alloc.trace.lsra.TraceLinearScan;
@@ -79,7 +78,6 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
     private static final TraceBuilderPhase TRACE_BUILDER_PHASE = new TraceBuilderPhase();
 
     public static final int TRACE_DUMP_LEVEL = 3;
-    private static final int TRACE_LOG_LEVEL = 1;
 
     private static final DebugMetric trivialTracesMetric = Debug.metric("TraceRA[trivialTraces]");
     private static final DebugMetric tracesMetric = Debug.metric("TraceRA[traces]");
@@ -134,15 +132,6 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
             @SuppressWarnings("unchecked")
             TraceBuilderResult<B> resultTraces = (TraceBuilderResult<B>) traceBuilderContext.traceBuilderResult;
 
-            assert TraceBuilderResult.verify(resultTraces, lirGenRes.getLIR().getControlFlowGraph().getBlocks().size());
-            if (Debug.isLogEnabled(TRACE_LOG_LEVEL)) {
-                List<Trace<B>> traces = resultTraces.getTraces();
-                for (int i = 0; i < traces.size(); i++) {
-                    Trace<B> trace = traces.get(i);
-                    Debug.log(TRACE_LOG_LEVEL, "Trace %5d: %s%s", i, trace, isTrivialTrace(lirGenRes.getLIR(), trace) ? " (trivial)" : "");
-                }
-            }
-            TraceStatisticsPrinter.printTraceStatistics(resultTraces, lirGenRes.getCompilationUnitName());
             Debug.dump(TRACE_DUMP_LEVEL, resultTraces, "After TraceBuilding");
             return resultTraces;
         }
@@ -166,22 +155,6 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
                 SSIUtil.removeOutgoing(lir, block);
             }
         }
-    }
-
-    static boolean isTrivialTrace(LIR lir, Trace<? extends AbstractBlockBase<?>> trace) {
-        if (trace.size() != 1) {
-            return false;
-        }
-        List<LIRInstruction> instructions = lir.getLIRforBlock(trace.getBlocks().iterator().next());
-        if (instructions.size() != 2) {
-            return false;
-        }
-        assert instructions.get(0) instanceof LabelOp : "First instruction not a LabelOp: " + instructions.get(0);
-        /*
-         * Now we need to check if the BlockEndOp has no special operand requirements (i.e.
-         * stack-slot, register). For now we just check for JumpOp because we know that it doesn't.
-         */
-        return instructions.get(1) instanceof JumpOp;
     }
 
     private static void unnumberInstructions(Collection<? extends AbstractBlockBase<?>> trace, LIR lir) {

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceTrivialAllocator.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceTrivialAllocator.java
@@ -24,7 +24,7 @@ package com.oracle.graal.lir.alloc.trace;
 
 import static com.oracle.graal.lir.LIRValueUtil.asVariable;
 import static com.oracle.graal.lir.LIRValueUtil.isVariable;
-import static com.oracle.graal.lir.alloc.trace.TraceRegisterAllocationPhase.isTrivialTrace;
+import static com.oracle.graal.lir.alloc.trace.TraceUtil.isTrivialTrace;
 
 import java.util.List;
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceUtil.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceUtil.java
@@ -24,8 +24,15 @@ package com.oracle.graal.lir.alloc.trace;
 
 import jdk.vm.ci.meta.Value;
 
+import java.util.List;
+
+import com.oracle.graal.compiler.common.alloc.Trace;
 import com.oracle.graal.compiler.common.alloc.TraceBuilderResult;
 import com.oracle.graal.compiler.common.cfg.AbstractBlockBase;
+import com.oracle.graal.lir.LIR;
+import com.oracle.graal.lir.LIRInstruction;
+import com.oracle.graal.lir.StandardOp.JumpOp;
+import com.oracle.graal.lir.StandardOp.LabelOp;
 
 public class TraceUtil {
 
@@ -50,5 +57,21 @@ public class TraceUtil {
     public static ShadowedRegisterValue asShadowedRegisterValue(Value value) {
         assert isShadowedRegisterValue(value);
         return (ShadowedRegisterValue) value;
+    }
+
+    static boolean isTrivialTrace(LIR lir, Trace<? extends AbstractBlockBase<?>> trace) {
+        if (trace.size() != 1) {
+            return false;
+        }
+        List<LIRInstruction> instructions = lir.getLIRforBlock(trace.getBlocks().iterator().next());
+        if (instructions.size() != 2) {
+            return false;
+        }
+        assert instructions.get(0) instanceof LabelOp : "First instruction not a LabelOp: " + instructions.get(0);
+        /*
+         * Now we need to check if the BlockEndOp has no special operand requirements (i.e.
+         * stack-slot, register). For now we just check for JumpOp because we know that it doesn't.
+         */
+        return instructions.get(1) instanceof JumpOp;
     }
 }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScan.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScan.java
@@ -52,6 +52,7 @@ import com.oracle.graal.lir.StandardOp.BlockEndOp;
 import com.oracle.graal.lir.ValueConsumer;
 import com.oracle.graal.lir.Variable;
 import com.oracle.graal.lir.VirtualStackSlot;
+import com.oracle.graal.lir.alloc.trace.TraceBuilderPhase;
 import com.oracle.graal.lir.alloc.trace.TraceRegisterAllocationPhase;
 import com.oracle.graal.lir.alloc.trace.lsra.TraceLinearScanAllocationPhase.TraceLinearScanAllocationContext;
 import com.oracle.graal.lir.framemap.FrameMapBuilder;
@@ -765,12 +766,12 @@ public final class TraceLinearScan {
 
                 // resolve intra-trace data-flow
                 TRACE_LINEAR_SCAN_RESOLVE_DATA_FLOW_PHASE.apply(target, lirGenRes, codeEmittingOrder, linearScanOrder, context, false);
-                Debug.dump(TraceRegisterAllocationPhase.TRACE_DUMP_LEVEL, sortedBlocks(), "%s", TRACE_LINEAR_SCAN_RESOLVE_DATA_FLOW_PHASE.getName());
+                Debug.dump(TraceBuilderPhase.TRACE_DUMP_LEVEL, sortedBlocks(), "%s", TRACE_LINEAR_SCAN_RESOLVE_DATA_FLOW_PHASE.getName());
 
                 // eliminate spill moves
                 if (Options.LIROptTraceRAEliminateSpillMoves.getValue()) {
                     TRACE_LINEAR_SCAN_ELIMINATE_SPILL_MOVE_PHASE.apply(target, lirGenRes, codeEmittingOrder, linearScanOrder, context, false);
-                    Debug.dump(TraceRegisterAllocationPhase.TRACE_DUMP_LEVEL, sortedBlocks(), "%s", TRACE_LINEAR_SCAN_ELIMINATE_SPILL_MOVE_PHASE.getName());
+                    Debug.dump(TraceBuilderPhase.TRACE_DUMP_LEVEL, sortedBlocks(), "%s", TRACE_LINEAR_SCAN_ELIMINATE_SPILL_MOVE_PHASE.getName());
                 }
 
                 TRACE_LINEAR_SCAN_ASSIGN_LOCATIONS_PHASE.apply(target, lirGenRes, codeEmittingOrder, linearScanOrder, context, false);
@@ -786,7 +787,7 @@ public final class TraceLinearScan {
 
     @SuppressWarnings("try")
     public void printIntervals(String label) {
-        if (Debug.isDumpEnabled(TraceRegisterAllocationPhase.TRACE_DUMP_LEVEL)) {
+        if (Debug.isDumpEnabled(TraceBuilderPhase.TRACE_DUMP_LEVEL)) {
             if (Debug.isLogEnabled()) {
                 try (Indent indent = Debug.logAndIndent("intervals %s", label)) {
                     for (FixedInterval interval : fixedIntervals) {
@@ -814,8 +815,8 @@ public final class TraceLinearScan {
     }
 
     public void printLir(String label, @SuppressWarnings("unused") boolean hirValid) {
-        if (Debug.isDumpEnabled(TraceRegisterAllocationPhase.TRACE_DUMP_LEVEL)) {
-            Debug.dump(TraceRegisterAllocationPhase.TRACE_DUMP_LEVEL, sortedBlocks(), label);
+        if (Debug.isDumpEnabled(TraceBuilderPhase.TRACE_DUMP_LEVEL)) {
+            Debug.dump(TraceBuilderPhase.TRACE_DUMP_LEVEL, sortedBlocks(), label);
         }
     }
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/AllocationStage.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/AllocationStage.java
@@ -28,6 +28,7 @@ import static com.oracle.graal.compiler.common.BackendOptions.UserOptions.TraceR
 import com.oracle.graal.compiler.common.GraalOptions;
 import com.oracle.graal.lir.alloc.AllocationStageVerifier;
 import com.oracle.graal.lir.alloc.lsra.LinearScanPhase;
+import com.oracle.graal.lir.alloc.trace.TraceBuilderPhase;
 import com.oracle.graal.lir.alloc.trace.TraceRegisterAllocationPhase;
 import com.oracle.graal.lir.dfa.LocationMarkerPhase;
 import com.oracle.graal.lir.dfa.MarkBasePointersPhase;
@@ -59,6 +60,7 @@ public class AllocationStage extends LIRPhaseSuite<AllocationContext> {
             }
         }
         if (TraceRA.getValue()) {
+            appendPhase(new TraceBuilderPhase());
             appendPhase(new TraceRegisterAllocationPhase());
         } else {
             appendPhase(new LinearScanPhase());

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/GenericContext.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/GenericContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,19 +22,36 @@
  */
 package com.oracle.graal.lir.phases;
 
-import com.oracle.graal.compiler.common.alloc.RegisterAllocationConfig;
-import com.oracle.graal.lir.gen.LIRGeneratorTool.MoveFactory;
+import java.util.ArrayList;
+import java.util.List;
 
-public abstract class AllocationPhase extends LIRPhase<AllocationPhase.AllocationContext> {
+/**
+ * Allows storing of arbitrary data.
+ */
+public class GenericContext {
 
-    public static final class AllocationContext extends GenericContext {
-        public final MoveFactory spillMoveFactory;
-        public final RegisterAllocationConfig registerAllocationConfig;
+    private List<Object> context;
 
-        public AllocationContext(MoveFactory spillMoveFactory, RegisterAllocationConfig registerAllocationConfig) {
-            this.spillMoveFactory = spillMoveFactory;
-            this.registerAllocationConfig = registerAllocationConfig;
-        }
+    public GenericContext() {
+        context = null;
     }
 
+    public <T> void contextAdd(T obj) {
+        if (context == null) {
+            context = new ArrayList<>();
+        }
+        context.add(obj);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T contextLookup(Class<T> clazz) {
+        if (context != null) {
+            for (Object e : context) {
+                if (clazz.isInstance(e)) {
+                    return (T) e;
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/LIRPhaseSuite.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/LIRPhaseSuite.java
@@ -85,7 +85,7 @@ public class LIRPhaseSuite<C> extends LIRPhase<C> {
     }
 
     @Override
-    protected <B extends AbstractBlockBase<B>> void run(TargetDescription target, LIRGenerationResult lirGenRes, List<B> codeEmittingOrder, List<B> linearScanOrder, C context) {
+    protected final <B extends AbstractBlockBase<B>> void run(TargetDescription target, LIRGenerationResult lirGenRes, List<B> codeEmittingOrder, List<B> linearScanOrder, C context) {
         for (LIRPhase<C> phase : phases) {
             phase.apply(target, lirGenRes, codeEmittingOrder, linearScanOrder, context);
         }


### PR DESCRIPTION
Trace building was previously called from within `TraceRegisterAllocation`. Doing this as separate phase is more modular.