### PR TITLE
Extension/verify debug usage

### DIFF
--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.compiler.test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.junit.Test;
+
+import com.oracle.graal.api.test.Graal;
+import com.oracle.graal.debug.Debug;
+import com.oracle.graal.debug.Indent;
+import com.oracle.graal.graph.Node;
+import com.oracle.graal.java.GraphBuilderPhase;
+import com.oracle.graal.nodes.StructuredGraph;
+import com.oracle.graal.nodes.StructuredGraph.AllowAssumptions;
+import com.oracle.graal.nodes.graphbuilderconf.GraphBuilderConfiguration;
+import com.oracle.graal.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
+import com.oracle.graal.nodes.graphbuilderconf.InvocationPlugins;
+import com.oracle.graal.phases.OptimisticOptimizations;
+import com.oracle.graal.phases.Phase;
+import com.oracle.graal.phases.PhaseSuite;
+import com.oracle.graal.phases.VerifyPhase.VerificationError;
+import com.oracle.graal.phases.tiers.HighTierContext;
+import com.oracle.graal.phases.util.Providers;
+import com.oracle.graal.phases.verify.VerifyDebugUsage;
+import com.oracle.graal.runtime.RuntimeProvider;
+
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+public class VerifyDebugUsageTest {
+
+    private static class InvalidLogUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            for (Node n : graph.getNodes()) {
+                Debug.log("%s", n.toString());
+            }
+        }
+
+    }
+
+    private static class InvalidLogAndIndentUsagePhase extends Phase {
+
+        @Override
+        @SuppressWarnings("try")
+        protected void run(StructuredGraph graph) {
+            try (Indent i = Debug.logAndIndent("%s", graph.toString())) {
+                for (Node n : graph.getNodes()) {
+                    Debug.log("%s", n);
+                }
+            }
+        }
+
+    }
+
+    private static class InvalidDumpUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            Debug.dump(graph, "%s", graph.toString());
+        }
+
+    }
+
+    private static class InvalidVerifyUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            Debug.verify(graph, "%s", graph.toString());
+        }
+
+    }
+
+    private static class InvalidConcatLogUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            for (Node n : graph.getNodes()) {
+                Debug.log("error " + n);
+            }
+        }
+
+    }
+
+    private static class InvalidConcatLogAndIndentUsagePhase extends Phase {
+
+        @Override
+        @SuppressWarnings("try")
+        protected void run(StructuredGraph graph) {
+            try (Indent i = Debug.logAndIndent("error " + graph)) {
+                for (Node n : graph.getNodes()) {
+                    Debug.log("%s", n);
+                }
+            }
+        }
+
+    }
+
+    private static class InvalidConcatDumpUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            Debug.dump(graph, "error " + graph);
+        }
+
+    }
+
+    private static class InvalidConcatVerifyUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            Debug.verify(graph, "error " + graph);
+        }
+
+    }
+
+    private static class ValidLogUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            for (Node n : graph.getNodes()) {
+                Debug.log("%s", n);
+            }
+        }
+
+    }
+
+    private static class ValidLogAndIndentUsagePhase extends Phase {
+
+        @Override
+        @SuppressWarnings("try")
+        protected void run(StructuredGraph graph) {
+            try (Indent i = Debug.logAndIndent("%s", graph)) {
+                for (Node n : graph.getNodes()) {
+                    Debug.log("%s", n);
+                }
+            }
+        }
+
+    }
+
+    private static class ValidDumpUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            Debug.dump(graph, "%s", graph);
+        }
+
+    }
+
+    private static class ValidVerifyUsagePhase extends Phase {
+
+        @Override
+        protected void run(StructuredGraph graph) {
+            Debug.verify(graph, "%s", graph);
+        }
+
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testLogInvalid() {
+        testDebugUsageClass(InvalidLogUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testLogAndIndentInvalid() {
+        testDebugUsageClass(InvalidLogAndIndentUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testVerifyInvalid() {
+        testDebugUsageClass(InvalidVerifyUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testDumpInvalid() {
+        testDebugUsageClass(InvalidDumpUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testLogInvalidConcat() {
+        testDebugUsageClass(InvalidConcatLogUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testLogAndIndentInvalidConcat() {
+        testDebugUsageClass(InvalidConcatLogAndIndentUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testVerifyInvalidConcat() {
+        testDebugUsageClass(InvalidConcatVerifyUsagePhase.class);
+    }
+
+    @Test(expected = VerificationError.class)
+    public void testDumpInvalidConcat() {
+        testDebugUsageClass(InvalidConcatDumpUsagePhase.class);
+    }
+
+    @Test
+    public void testLogValid() {
+        testDebugUsageClass(ValidLogUsagePhase.class);
+    }
+
+    @Test()
+    public void testLogAndIndentValid() {
+        testDebugUsageClass(ValidLogAndIndentUsagePhase.class);
+    }
+
+    @Test
+    public void testVerifyValid() {
+        testDebugUsageClass(ValidVerifyUsagePhase.class);
+    }
+
+    @Test
+    public void testDumpValid() {
+        testDebugUsageClass(ValidDumpUsagePhase.class);
+    }
+
+    private static void testDebugUsageClass(Class<?> c) {
+        RuntimeProvider rt = Graal.getRequiredCapability(RuntimeProvider.class);
+        Providers providers = rt.getHostBackend().getProviders();
+        MetaAccessProvider metaAccess = providers.getMetaAccess();
+        PhaseSuite<HighTierContext> graphBuilderSuite = new PhaseSuite<>();
+        GraphBuilderConfiguration config = GraphBuilderConfiguration.getEagerDefault(new Plugins(new InvocationPlugins(metaAccess)));
+        graphBuilderSuite.appendPhase(new GraphBuilderPhase(config));
+        HighTierContext context = new HighTierContext(providers, graphBuilderSuite, OptimisticOptimizations.NONE);
+        for (Method m : c.getDeclaredMethods()) {
+            if (!Modifier.isNative(m.getModifiers()) && !Modifier.isAbstract(m.getModifiers())) {
+                ResolvedJavaMethod method = metaAccess.lookupJavaMethod(m);
+                StructuredGraph graph = new StructuredGraph(method, AllowAssumptions.NO);
+                graphBuilderSuite.apply(graph, context);
+                new VerifyDebugUsage().apply(graph, context);
+            }
+        }
+    }
+}

--- a/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/GraalDebugConfig.java
+++ b/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/GraalDebugConfig.java
@@ -284,7 +284,7 @@ public class GraalDebugConfig implements DebugConfig {
             // Only dump a context object once.
             if (firstSeen.add(o)) {
                 if (Options.DumpOnError.getValue()) {
-                    Debug.dump(o, "Exception: " + e.toString());
+                    Debug.dump(o, "Exception: %s", e);
                 } else {
                     Debug.log("Context obj %s", o);
                 }

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -579,7 +579,8 @@ public class BytecodeParser implements GraphBuilderContext {
     private FixedWithNextNode[] firstInstructionArray;
     private FrameStateBuilder[] entryStateArray;
 
-    protected BytecodeParser(GraphBuilderPhase.Instance graphBuilderInstance, StructuredGraph graph, BytecodeParser parent, ResolvedJavaMethod method, int entryBCI, IntrinsicContext intrinsicContext) {
+    protected BytecodeParser(GraphBuilderPhase.Instance graphBuilderInstance, StructuredGraph graph, BytecodeParser parent, ResolvedJavaMethod method, int entryBCI,
+                    IntrinsicContext intrinsicContext) {
         this.graphBuilderInstance = graphBuilderInstance;
         this.graph = graph;
         this.graphBuilderConfig = graphBuilderInstance.graphBuilderConfig;
@@ -723,7 +724,7 @@ public class BytecodeParser implements GraphBuilderContext {
             }
 
             if (Debug.isDumpEnabled() && DumpDuringGraphBuilding.getValue() && this.beforeReturnNode != startInstruction) {
-                Debug.dump(graph, "Bytecodes parsed: " + method.getDeclaringClass().getUnqualifiedName() + "." + method.getName());
+                Debug.dump(graph, "Bytecodes parsed: %s.%s", method.getDeclaringClass().getUnqualifiedName(), method.getName());
             }
         }
     }
@@ -1608,7 +1609,8 @@ public class BytecodeParser implements GraphBuilderContext {
 
     protected void traceWithContext(String format, Object... args) {
         StackTraceElement where = method.asStackTraceElement(bci());
-        TTY.println(format("%s%s (%s:%d) %s", nSpaces(getDepth()), method.isConstructor() ? method.format("%h.%n") : method.getName(), where.getFileName(), where.getLineNumber(), format(format, args)));
+        TTY.println(format("%s%s (%s:%d) %s", nSpaces(getDepth()), method.isConstructor() ? method.format("%h.%n") : method.getName(), where.getFileName(), where.getLineNumber(),
+                        format(format, args)));
     }
 
     protected BytecodeParserError asParserError(Throwable e) {
@@ -2908,7 +2910,8 @@ public class BytecodeParser implements GraphBuilderContext {
          * interfaces are initialized only under special circumstances, so that this assertion would
          * often fail for interface calls.
          */
-        assert !graphBuilderConfig.unresolvedIsError() || (result instanceof ResolvedJavaMethod && (opcode != INVOKESTATIC || ((ResolvedJavaMethod) result).getDeclaringClass().isInitialized())) : result;
+        assert !graphBuilderConfig.unresolvedIsError() ||
+                        (result instanceof ResolvedJavaMethod && (opcode != INVOKESTATIC || ((ResolvedJavaMethod) result).getDeclaringClass().isInitialized())) : result;
         return result;
     }
 

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -2064,8 +2064,9 @@ public class BytecodeParser implements GraphBuilderContext {
         FixedNode target = createTarget(probability, block, stateAfter);
         AbstractBeginNode begin = BeginNode.begin(target);
 
-        assert !(target instanceof DeoptimizeNode && begin instanceof BeginStateSplitNode && ((BeginStateSplitNode) begin).stateAfter() != null) : "We are not allowed to set the stateAfter of the begin node, because we have to deoptimize "
-                        + "to a bci _before_ the actual if, so that the interpreter can update the profiling information.";
+        assert !(target instanceof DeoptimizeNode && begin instanceof BeginStateSplitNode && ((BeginStateSplitNode) begin).stateAfter() != null) : "We are not allowed to set the stateAfter of the begin node,"
+                        +
+                        " because we have to deoptimize to a bci _before_ the actual if, so that the interpreter can update the profiling information.";
         return begin;
     }
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScanWalker.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScanWalker.java
@@ -849,8 +849,7 @@ class LinearScanWalker extends IntervalWalker {
                             Debug.log("retry with register priority must have register");
                             continue;
                         }
-                        String description = "cannot spill interval (" + interval + ") that is used in first instruction (possible reason: no register found) firstUsage=" + firstUsage +
-                                        ", interval.from()=" + interval.from() + "; already used candidates: " + Arrays.toString(availableRegs);
+                        String description = generateOutOfRegErrorMsg(interval, firstUsage, availableRegs);
                         /*
                          * assign a reasonable register and do a bailout in product mode to avoid
                          * errors
@@ -887,6 +886,11 @@ class LinearScanWalker extends IntervalWalker {
             splitAndSpillIntersectingIntervals(reg);
             return;
         }
+    }
+
+    private static String generateOutOfRegErrorMsg(Interval interval, int firstUsage, Register[] availableRegs) {
+        return "Cannot spill interval (" + interval + ") that is used in first instruction (possible reason: no register found) firstUsage=" + firstUsage +
+                        ", interval.from()=" + interval.from() + "; already used candidates: " + Arrays.toString(availableRegs);
     }
 
     @SuppressWarnings("try")

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/constopt/ConstantLoadOptimization.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/constopt/ConstantLoadOptimization.java
@@ -288,7 +288,7 @@ public final class ConstantLoadOptimization extends PreAllocationOptimizationPha
                 // no better solution found
                 materializeAtDefinitionSkipped.increment();
             }
-            Debug.dump(constTree, "ConstantTree for " + tree.getVariable());
+            Debug.dump(constTree, "ConstantTree for %s", tree.getVariable());
         }
 
         private void createLoads(DefUseTree tree, ConstantTree constTree, AbstractBlockBase<?> startBlock) {

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/instrumentation/ExtractInstrumentationPhase.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/instrumentation/ExtractInstrumentationPhase.java
@@ -68,7 +68,7 @@ public class ExtractInstrumentationPhase extends BasePhase<HighTierContext> {
             if (!instrumentation.inspectingIntrinsic()) {
                 InstrumentationNode instrumentationNode = instrumentation.createInstrumentationNode();
                 graph.addBeforeFixed(begin, instrumentationNode);
-                Debug.dump(instrumentationNode.instrumentationGraph(), "After extracted instrumentation at " + instrumentation);
+                Debug.dump(instrumentationNode.instrumentationGraph(), "After extracted instrumentation at %s", instrumentation);
             }
             instrumentation.unlink();
         }

--- a/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/verify/VerifyDebugUsage.java
+++ b/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/verify/VerifyDebugUsage.java
@@ -37,12 +37,12 @@ import jdk.vm.ci.meta.ResolvedJavaType;
 
 /**
  *
- * Verifies that callsites calling on of the methods in {@link Debug} use them correctly. Correct
+ * Verifies that callsites calling one of the methods in {@link Debug} use them correctly. Correct
  * usage of the methods in {@link Debug} requires callsites to not eagerly evaluate their arguments.
  * Additionally this phase verifies that no argument is the result of a call to
  * {@link StringBuilder#toString()} or {@link StringBuffer#toString()}. Ideally the parameters at
  * callsites of {@link Debug} are eliminated, and do not produce additional allocations, if
- * {@link Debug#isDumpEnabled()} (or {@link Debug#isLogEnabled()}, ...) is <code>false</code>.
+ * {@link Debug#isDumpEnabled()} (or {@link Debug#isLogEnabled()}, ...) is {@code false}.
  *
  * Methods in {@link Debug} checked by this phase are various different versions of
  * {@link Debug#log(String)} , {@link Debug#dump(Object, String)},

--- a/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/verify/VerifyDebugUsage.java
+++ b/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/verify/VerifyDebugUsage.java
@@ -22,62 +22,84 @@
  */
 package com.oracle.graal.phases.verify;
 
-import jdk.vm.ci.meta.ResolvedJavaMethod;
-import jdk.vm.ci.meta.ResolvedJavaType;
-
 import com.oracle.graal.debug.Debug;
+import com.oracle.graal.graph.Node;
+import com.oracle.graal.graph.NodeInputList;
 import com.oracle.graal.nodes.CallTargetNode;
 import com.oracle.graal.nodes.Invoke;
 import com.oracle.graal.nodes.StructuredGraph;
-import com.oracle.graal.nodes.ValueNode;
 import com.oracle.graal.nodes.java.MethodCallTargetNode;
 import com.oracle.graal.phases.VerifyPhase;
 import com.oracle.graal.phases.tiers.PhaseContext;
 
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
+
 /**
- * Verifies that no argument to one of the {@link Debug#log(String)} methods is the result of
- * {@link StringBuilder#toString()} or {@link StringBuffer#toString()}. Instead, one of the
- * multi-parameter {@code log()} methods should be used. The goal is to minimize/prevent allocation
- * at logging call sites.
+ *
+ * Verifies that callsites calling on of the methods in {@link Debug} use them correctly. Correct
+ * usage of the methods in {@link Debug} requires callsites to not eagerly evaluate their arguments.
+ * Additionally this phase verifies that no argument is the result of a call to
+ * {@link StringBuilder#toString()} or {@link StringBuffer#toString()}. Ideally the parameters at
+ * callsites of {@link Debug} are eliminated, and do not produce additional allocations, if
+ * {@link Debug#isDumpEnabled()} (or {@link Debug#isLogEnabled()}, ...) is <code>false</code>.
+ *
+ * Methods in {@link Debug} checked by this phase are various different versions of
+ * {@link Debug#log(String)} , {@link Debug#dump(Object, String)},
+ * {@link Debug#logAndIndent(String)} and {@link Debug#verify(Object, String)}.
  */
 public class VerifyDebugUsage extends VerifyPhase<PhaseContext> {
 
     @Override
     protected boolean verify(StructuredGraph graph, PhaseContext context) {
+        ResolvedJavaType debugType = context.getMetaAccess().lookupJavaType(Debug.class);
+        ResolvedJavaType stringType = context.getMetaAccess().lookupJavaType(String.class);
         for (MethodCallTargetNode t : graph.getNodes(MethodCallTargetNode.TYPE)) {
             ResolvedJavaMethod callee = t.targetMethod();
-            ResolvedJavaType debugType = context.getMetaAccess().lookupJavaType(Debug.class);
+            String calleeName = callee.getName();
             if (callee.getDeclaringClass().equals(debugType)) {
-                if (callee.getName().equals("log")) {
-                    int argIdx = 1;
-                    for (ValueNode arg : t.arguments()) {
-                        if (arg instanceof Invoke) {
-                            Invoke invoke = (Invoke) arg;
-                            CallTargetNode callTarget = invoke.callTarget();
-                            if (callTarget instanceof MethodCallTargetNode) {
-                                ResolvedJavaMethod m = ((MethodCallTargetNode) callTarget).targetMethod();
-                                if (m.getName().equals("toString")) {
-                                    String holder = m.getDeclaringClass().getName();
-                                    if (holder.equals("Ljava/lang/StringBuilder;") || holder.equals("Ljava/lang/StringBuffer;")) {
-                                        StackTraceElement e = graph.method().asStackTraceElement(invoke.bci());
-                                        throw new VerificationError(String.format("%s: parameter %d of call to %s appears to be a String concatenation expression.%n" +
-                                                        "    Use one of the multi-parameter Debug.log() methods or Debug.logv() instead.", e, argIdx, callee.format("%H.%n(%p)")));
-                                    }
-                                    if (m.getSignature().getParameterCount(false) == 0 && m.getSignature().getReturnType(m.getDeclaringClass()).equals(
-                                                    context.getMetaAccess().lookupJavaType(String.class))) {
-                                        StackTraceElement e = graph.method().asStackTraceElement(invoke.bci());
-                                        throw new VerificationError(String.format("%s: parameter %d of call to %s appears to be a toString call without a parameter. %n " +
-                                                        "   Calls to toString() are made by Debug.log() and should thus be avoided.", e,
-                                                        argIdx, callee.format("%H.%n(%p)")));
-                                    }
-                                }
-                            }
-                        }
-                        argIdx++;
-                    }
+                if (calleeName.equals("log") || calleeName.equals("logAndIndent") || calleeName.equals("verify") || calleeName.equals("dump")) {
+                    verifyParameters(graph, t.arguments(), stringType, calleeName.equals("dump") ? 2 : 1);
                 }
             }
         }
         return true;
+    }
+
+    private static void verifyParameters(StructuredGraph graph, NodeInputList<? extends Node> args, ResolvedJavaType stringType, int startArgIdx) {
+        int argIdx = startArgIdx;
+        for (Node arg : args) {
+            if (arg instanceof Invoke) {
+                Invoke invoke = (Invoke) arg;
+                CallTargetNode callTarget = invoke.callTarget();
+                if (callTarget instanceof MethodCallTargetNode) {
+                    ResolvedJavaMethod m = ((MethodCallTargetNode) callTarget).targetMethod();
+                    if (m.getName().equals("toString")) {
+                        int bci = invoke.bci();
+                        verifyStringConcat(graph, bci, argIdx, m);
+                        verifyToStringCall(graph, stringType, m, bci, argIdx);
+                    }
+                }
+            }
+            argIdx++;
+        }
+    }
+
+    private static void verifyStringConcat(StructuredGraph graph, int bci, int argIdx, ResolvedJavaMethod callee) {
+        if (callee.getDeclaringClass().getName().equals("Ljava/lang/StringBuilder;") || callee.getDeclaringClass().getName().equals("Ljava/lang/StringBuffer;")) {
+            StackTraceElement e = graph.method().asStackTraceElement(bci);
+            throw new VerificationError(String.format("%s: parameter %d of call to %s appears to be a String concatenation expression.%n" +
+                            "    Use one of the multi-parameter Debug.log() methods or Debug.logv() instead.", e, argIdx, callee.format("%H.%n(%p)")));
+        }
+    }
+
+    private static void verifyToStringCall(StructuredGraph graph, ResolvedJavaType stringType, ResolvedJavaMethod callee, int bci, int argIdx) {
+        if (callee.getSignature().getParameterCount(false) == 0 && callee.getSignature().getReturnType(callee.getDeclaringClass()).equals(stringType)) {
+            StackTraceElement e = graph.method().asStackTraceElement(bci);
+            throw new VerificationError(
+                            String.format("%s: parameter %d of call to %s is a call to toString() which is redundant (the callee will do it) and forces unnecessary eager evaluation.",
+                                            e,
+                                            argIdx, callee.format("%H.%n(%p)")));
+        }
     }
 }

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
@@ -580,7 +580,7 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         }
 
         if (Debug.isDumpEnabled() && DumpDuringGraphBuilding.getValue()) {
-            Debug.dump(methodScope.graph, "Inline finished: " + inlineMethod.getDeclaringClass().getUnqualifiedName() + "." + inlineMethod.getName());
+            Debug.dump(methodScope.graph, "Inline finished: %s.%s", inlineMethod.getDeclaringClass().getUnqualifiedName(), inlineMethod.getName());
         }
         return true;
     }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/substitutions/TruffleGraphBuilderPlugins.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/substitutions/TruffleGraphBuilderPlugins.java
@@ -318,7 +318,7 @@ public class TruffleGraphBuilderPlugins {
                         sb.append(")");
                     }
                     Debug.dump(value.graph(), "Graph before bailout at node %s", sb);
-                    throw b.bailout("Partial evaluation did not reduce value to a constant, is a regular compiler node: " + sb.toString());
+                    throw b.bailout("Partial evaluation did not reduce value to a constant, is a regular compiler node: " + sb);
                 }
             }
         });

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/substitutions/TruffleGraphBuilderPlugins.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/substitutions/TruffleGraphBuilderPlugins.java
@@ -230,7 +230,7 @@ public class TruffleGraphBuilderPlugins {
                      * and constant folding could still eliminate the call to bailout(). However, we
                      * also want to stop parsing, since we are sure that we will never need the
                      * graph beyond the bailout point.
-                     * 
+                     *
                      * Therefore, we manually emit the call to bailout, which will be intrinsified
                      * later when intrinsifications can no longer be delayed. The call is followed
                      * by a NeverPartOfCompilationNode, which is a control sink and therefore stops
@@ -317,9 +317,8 @@ public class TruffleGraphBuilderPlugins {
                         }
                         sb.append(")");
                     }
-                    String nodeDescription = sb.toString();
-                    Debug.dump(value.graph(), "Graph before bailout at node " + nodeDescription);
-                    throw b.bailout("Partial evaluation did not reduce value to a constant, is a regular compiler node: " + nodeDescription);
+                    Debug.dump(value.graph(), "Graph before bailout at node %s", sb);
+                    throw b.bailout("Partial evaluation did not reduce value to a constant, is a regular compiler node: " + sb.toString());
                 }
             }
         });

--- a/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/EffectsPhase.java
+++ b/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/EffectsPhase.java
@@ -101,7 +101,7 @@ public abstract class EffectsPhase<PhaseContextT extends PhaseContext> extends B
                     }
 
                     if (Debug.isDumpEnabled()) {
-                        Debug.dump(graph, getName() + " iteration");
+                        Debug.dump(graph, "%s iteration", getName());
                     }
 
                     new DeadCodeEliminationPhase(Required).apply(graph);


### PR DESCRIPTION
Follow-up of #88 .
Introduces the checks for parameterless `toString` calls and `StringBuilder` and `StringBuffer` concatenations on Debug methods `log`, `logAndIndent`, `dump` & `verify`

cc @zapster 