### PR TITLE
Using TruffleServices instead of direct access to Accessor

### DIFF
--- a/graal/com.oracle.graal.truffle.hotspot/src/com/oracle/graal/truffle/hotspot/HotSpotTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle.hotspot/src/com/oracle/graal/truffle/hotspot/HotSpotTruffleRuntime.java
@@ -184,7 +184,7 @@ public final class HotSpotTruffleRuntime extends GraalTruffleRuntime {
         } else {
             compilationPolicy = new InterpreterOnlyCompilationPolicy();
         }
-        OptimizedCallTarget target = new OptimizedCallTarget(source, rootNode, this, compilationPolicy, new HotSpotSpeculationLog());
+        OptimizedCallTarget target = new OptimizedCallTarget(source, rootNode, compilationPolicy, new HotSpotSpeculationLog());
         rootNode.setCallTarget(target);
         callTargets.put(target, null);
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTVMCI.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTVMCI.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.truffle;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.impl.TVMCI;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
+
+final class GraalTVMCI extends TVMCI {
+
+    @Override
+    public void onLoopCount(Node source, int count) {
+        Node node = source;
+        Node parentNode = source != null ? source.getParent() : null;
+        while (node != null) {
+            if (node instanceof OptimizedOSRLoopNode) {
+                ((OptimizedOSRLoopNode) node).reportChildLoopCount(count);
+            }
+            parentNode = node;
+            node = node.getParent();
+        }
+        if (parentNode != null && parentNode instanceof RootNode) {
+            CallTarget target = ((RootNode) parentNode).getCallTarget();
+            if (target instanceof OptimizedCallTarget) {
+                ((OptimizedCallTarget) target).onLoopCount(count);
+            }
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    Class<? extends TruffleLanguage> findLanguage(RootNode root) {
+        return super.findLanguageClass(root);
+    }
+
+    void onFirstExecution(OptimizedCallTarget callTarget) {
+        super.onFirstExecution(callTarget.getRootNode());
+    }
+
+}

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/GraalTruffleRuntime.java
@@ -68,6 +68,7 @@ import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.FrameInstanceVisitor;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.impl.TVMCI;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.LoopNode;
@@ -118,9 +119,14 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
     protected CallMethods callMethods;
 
     private final Supplier<GraalRuntime> graalRuntime;
+    private final GraalTVMCI tvmci = new GraalTVMCI();
 
     public GraalTruffleRuntime(Supplier<GraalRuntime> graalRuntime) {
         this.graalRuntime = graalRuntime;
+    }
+
+    GraalTVMCI getTvmci() {
+        return tvmci;
     }
 
     public abstract TruffleCompiler getTruffleCompiler();
@@ -305,7 +311,11 @@ public abstract class GraalTruffleRuntime implements TruffleRuntime {
         return iterateImpl(frame -> frame, 0);
     }
 
+    @Override
     public <T> T getCapability(Class<T> capability) {
+        if (capability.isAssignableFrom(TVMCI.class)) {
+            return capability.cast(tvmci);
+        }
         return null;
     }
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedOSRLoopNode.java
@@ -211,18 +211,22 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
         });
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private OSRRootNode createRootNodeImpl(RootNode root, Class<? extends VirtualFrame> frameClass) {
-        @SuppressWarnings("rawtypes")
-        Class<? extends TruffleLanguage> truffleLanguage;
+        Class truffleLanguage;
         FrameDescriptor frameDescriptor;
         if (root != null) {
-            truffleLanguage = OptimizedCallTarget.ACCESSOR.findLanguage(root);
+            truffleLanguage = runtime().getTvmci().findLanguage(root);
             frameDescriptor = root.getFrameDescriptor();
         } else {
             truffleLanguage = TruffleLanguage.class;
             frameDescriptor = new FrameDescriptor();
         }
         return createRootNode(truffleLanguage, frameDescriptor, frameClass);
+    }
+
+    private static GraalTruffleRuntime runtime() {
+        return (GraalTruffleRuntime) Truffle.getRuntime();
     }
 
     private OptimizedCallTarget compileImpl(VirtualFrame frame) {
@@ -580,4 +584,5 @@ public abstract class OptimizedOSRLoopNode extends LoopNode implements ReplaceOb
         }
 
     }
+
 }

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -47,7 +47,7 @@ suite = {
             },
             {
                "name" : "truffle",
-               "version" : "f322868c76f775a399bf96915c95e077c4f2c08c",
+               "version" : "1996803c8f0a63d6e19721061f738efacfcb5c80",
                "urls" : [
                     {"url" : "https://github.com/graalvm/truffle.git", "kind" : "git"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
This pull request contains changes in graal-core to use work done on
https://github.com/jtulach/truffle/tree/TruffleServices
branch. The changes in Truffle repository introduce new module `com.oracle.truffle.api.boot` - the idea is that at the end, this will be the only module on bootclasspath - the rest of the Truffle could stay on application classpath.

The module introduces `TruffleServices` class that shall include various methods returning *services* useful for the Truffle API. Right now it only provides the LoopCountSupport - that allows us to remove the dependency of Graal on `Accessor` class of Truffle.

I am not very happy with [current state](https://github.com/jtulach/truffle/commit/84f6950882a7d435737d09970a32dd6ee3765923), but at least it sketches the plan I am trying to follow. Comments welcomed.