### PR TITLE
mx gate: make TestJMH task fail on error.

### DIFF
--- a/mx.graal-core/mx_graal_8.py
+++ b/mx.graal-core/mx_graal_8.py
@@ -214,7 +214,7 @@ class MicrobenchRun:
 
     def run(self, tasks, extraVMarguments=None):
         with Task(self.name + ': hosted-product ', tasks, tags=self.tags) as t:
-            if t: mx_microbench.get_microbenchmark_executor().microbench(_noneAsEmptyList(extraVMarguments) + ['--'] + self.args)
+            if t: mx_microbench.get_microbenchmark_executor().microbench(_noneAsEmptyList(extraVMarguments) + ['--', '-foe', 'true'] + self.args)
 
 class GraalTags:
     test = 'test'

--- a/mx.graal-core/mx_graal_9.py
+++ b/mx.graal-core/mx_graal_9.py
@@ -195,7 +195,7 @@ class MicrobenchRun:
 
     def run(self, tasks, extraVMarguments=None):
         with Task(self.name + ': hosted-product ', tasks, tags=self.tags) as t:
-            if t: mx_microbench.get_microbenchmark_executor().microbench(_noneAsEmptyList(extraVMarguments) + ['--'] + self.args)
+            if t: mx_microbench.get_microbenchmark_executor().microbench(_noneAsEmptyList(extraVMarguments) + ['--', '-foe', 'true'] + self.args)
 
 class GraalTags:
     test = 'test'


### PR DESCRIPTION
Unfortunately, JMH always exits with zero return code per default even in case of an error. At least for JMH tasks in the gate we want fail-on-error behavior.