### PR TITLE
Fix/verify debug usage testing

### DIFF
--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.oracle.graal.api.test.Graal;
 import com.oracle.graal.debug.Debug;
+import com.oracle.graal.debug.DebugConfigScope;
 import com.oracle.graal.debug.Indent;
 import com.oracle.graal.graph.Node;
 import com.oracle.graal.java.GraphBuilderPhase;
@@ -240,6 +241,7 @@ public class VerifyDebugUsageTest {
         testDebugUsageClass(ValidDumpUsagePhase.class);
     }
 
+    @SuppressWarnings("try")
     private static void testDebugUsageClass(Class<?> c) {
         RuntimeProvider rt = Graal.getRequiredCapability(RuntimeProvider.class);
         Providers providers = rt.getHostBackend().getProviders();
@@ -253,7 +255,9 @@ public class VerifyDebugUsageTest {
                 ResolvedJavaMethod method = metaAccess.lookupJavaMethod(m);
                 StructuredGraph graph = new StructuredGraph(method, AllowAssumptions.NO);
                 graphBuilderSuite.apply(graph, context);
-                new VerifyDebugUsage().apply(graph, context);
+                try (DebugConfigScope s = Debug.disableIntercept()) {
+                    new VerifyDebugUsage().apply(graph, context);
+                }
             }
         }
     }

--- a/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/GraalDebugConfig.java
+++ b/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/GraalDebugConfig.java
@@ -278,7 +278,7 @@ public class GraalDebugConfig implements DebugConfig {
             return null;
         }
         Debug.setConfig(Debug.fixedConfig(Debug.DEFAULT_LOG_LEVEL, Debug.DEFAULT_LOG_LEVEL, false, false, false, false, dumpHandlers, verifyHandlers, output));
-        Debug.log(String.format("Exception occurred in scope: %s", Debug.currentScope()));
+        Debug.log("Exception occurred in scope: %s", Debug.currentScope());
         HashSet<Object> firstSeen = new HashSet<>();
         for (Object o : Debug.context()) {
             // Only dump a context object once.


### PR DESCRIPTION
PR #134 introduced a new class [VerifyDebugUsageTest](https://github.com/davleopo/graal-core/blob/bcc38a72966c61564fa2b0e52196f93ff7a48d09/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java) that tests several usages of `Debug.*` methods. 

Those tests that are expected to throw an exception should not intercept them to avoid a dump of the excp to stdout

cc @rschatz 