### PR TITLE
Dump full scheduled graph when G1 barrier addition test fails

### DIFF
--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GraalCompilerTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GraalCompilerTest.java
@@ -411,6 +411,34 @@ public abstract class GraalCompilerTest extends GraalTest {
         return constantsLines.toString() + result.toString();
     }
 
+    /**
+     * @param graph
+     * @return a scheduled textual dump of {@code graph} .
+     */
+    protected static String getScheduledGraphString(StructuredGraph graph) {
+        SchedulePhase schedule = new SchedulePhase(SchedulingStrategy.EARLIEST);
+        schedule.apply(graph);
+        ScheduleResult scheduleResult = graph.getLastSchedule();
+
+        StringBuilder result = new StringBuilder();
+        List<Block> blocks = scheduleResult.getCFG().getBlocks();
+        for (Block block : blocks) {
+            result.append("Block " + block + " ");
+            if (block == scheduleResult.getCFG().getStartBlock()) {
+                result.append("* ");
+            }
+            result.append("-> ");
+            for (Block succ : block.getSuccessors()) {
+                result.append(succ + " ");
+            }
+            result.append("\n");
+            for (Node node : scheduleResult.getBlockToNodesMap().get(block)) {
+                result.append(String.format("%1S\n", node));
+            }
+        }
+        return result.toString();
+    }
+
     protected Backend getBackend() {
         return backend;
     }

--- a/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/WriteBarrierAdditionTest.java
+++ b/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/WriteBarrierAdditionTest.java
@@ -147,8 +147,6 @@ public class WriteBarrierAdditionTest extends HotSpotGraalCompilerTest {
      */
     @Test
     public void test4() throws Exception {
-        // Exercise the snippet before compiling it to ensure that everything is resolved.
-        test4Snippet();
         testHelper("test4Snippet", config.useG1GC ? 5 : 2);
     }
 
@@ -279,7 +277,7 @@ public class WriteBarrierAdditionTest extends HotSpotGraalCompilerTest {
                 barriers = graph.getNodes().filter(SerialWriteBarrier.class).count();
             }
             if (expectedBarriers != barriers) {
-                Assert.assertEquals("UseG1GC = " + config.useG1GC + " " + getCanonicalGraphString(graph, false, false), expectedBarriers, barriers);
+                Assert.assertEquals(getScheduledGraphString(graph), expectedBarriers, barriers);
             }
             for (WriteNode write : graph.getNodes().filter(WriteNode.class)) {
                 if (config.useG1GC) {


### PR DESCRIPTION
The previous attempt at a blind fix didn't work, https://travis-ci.org/graalvm/graal-core/jobs/116949637.  So instead we'll dump a full text graph when it fail in hopes of a clue.  It's basically the "%1S" format of every node in schedule order like so:

<pre>
Block B0 * ->
0|StartNode { stamp=void,  } stateAfter={1|FrameState@0}
16|Constant(12) { rawvalue=12, stamp=i64 [12] ?000000000000000c ?000000000000000c, value=long[12|0xc],  }
12|Constant(104) { rawvalue=104, stamp=i64 [104] ?0000000000000068 ?0000000000000068, value=long[104|0x68],  }
11|Constant(Class:com.oracle.graal.hotspot.test.WriteBarrierAdditionTest) { rawvalue=Class:com.oracle.graal.hotspot.test.WriteBarrierAdditionTest, stamp=a!# Ljava/lang/Class;, value=Object[Class:com.oracle.graal.hotspot.test.WriteBarrierAdditionTest],  }
13|OffsetAddress { stamp=void*,  } base={11|Constant(Class:com.oracle.graal.hotspot.test.WriteBarrierAdditionTest)} offset={12|Constant(104)}
1|FrameState@0 { sourceLine=172, stackSize=0, duringCall=false, method=HotSpotMethod<WriteBarrierAdditionTest.test5Snippet()>, locksSize=0, localsSize=0, rethrowException=false, bci=0, sourceFile=WriteBarrierAdditionTest.java,  }
14|Read { barrierType=NONE, stamp=n Ljava/lang/ref/WeakReference;, location=wr, forceFixed=false, nullCheck=false,  } pred={0|StartNode} address={13|OffsetAddress}
15|Compression { op=Uncompress, stamp=a Ljava/lang/ref/WeakReference;, encoding=base: 0 shift: 3 alignment: 3,  } value={14|Read}
17|OffsetAddress { stamp=void*,  } base={15|Compression} offset={16|Constant(12)}
18|Read { barrierType=PRECISE, stamp=n Ljava/lang/Object;, location=referent, forceFixed=false, nullCheck=true,  } pred={14|Read} address={17|OffsetAddress}
19|Compression { op=Uncompress, stamp=a Ljava/lang/Object;, encoding=base: 0 shift: 3 alignment: 3,  } value={18|Read}
22|G1ReferentFieldReadBarrier { doLoad=false, stamp=void, precise=true,  } pred={18|Read} address={17|OffsetAddress} value={18|Read}
9|Return { stamp=void,  } pred={22|G1ReferentFieldReadBarrier} result={19|Compression}
</pre>

cc @rschatz 