### PR TITLE
Update jvmci import.

### DIFF
--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -39,7 +39,7 @@ suite = {
             {
                "name" : "jvmci",
                "optional" : "true",
-               "version" : "19c85f6618ede3f6d130f38ed0f815c8668bb010",
+               "version" : "bc5552dc384b7e07dc02529cd16ebaca712b0302",
                "urls" : [
                     {"url" : "http://lafo.ssw.uni-linz.ac.at/hg/graal-jvmci-8", "kind" : "hg"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
The new jvmci version prints stack traces of uncaught exceptions using VM routines, instead of calling the `Throwable.printStackTrace` method. This makes it easier to debug fatal errors that prevent the execution of more java code (e.g. class loader errors).