### PR TITLE
LSRA: deactivate spill position optimization.

### DIFF
--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/OptimizingLinearScanWalker.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/OptimizingLinearScanWalker.java
@@ -45,7 +45,7 @@ public class OptimizingLinearScanWalker extends LinearScanWalker {
     public static class Options {
         // @formatter:off
         @Option(help = "Enable LSRA optimization", type = OptionType.Debug)
-        public static final OptionValue<Boolean> LSRAOptimization = new OptionValue<>(true);
+        public static final OptionValue<Boolean> LSRAOptimization = new OptionValue<>(false);
         @Option(help = "LSRA optimization: Only split but do not reassign", type = OptionType.Debug)
         public static final OptionValue<Boolean> LSRAOptSplitOnly = new OptionValue<>(false);
         // @formatter:on

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/AllocationStage.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/AllocationStage.java
@@ -35,18 +35,8 @@ import com.oracle.graal.lir.phases.AllocationPhase.AllocationContext;
 import com.oracle.graal.lir.ssi.SSIConstructionPhase;
 import com.oracle.graal.lir.stackslotalloc.LSStackSlotAllocator;
 import com.oracle.graal.lir.stackslotalloc.SimpleStackSlotAllocator;
-import com.oracle.graal.options.Option;
-import com.oracle.graal.options.OptionType;
-import com.oracle.graal.options.StableOptionValue;
 
 public class AllocationStage extends LIRPhaseSuite<AllocationContext> {
-
-    public static class Options {
-        // @formatter:off
-        @Option(help = "Use fast SSI construction.", type = OptionType.Debug)
-        public static final StableOptionValue<Boolean> LIROptFastSSIConstruction = new StableOptionValue<>(true);
-        // @formatter:on
-    }
 
     public AllocationStage() {
         appendPhase(new MarkBasePointersPhase());


### PR DESCRIPTION
The spill position optimization has a sub-optimal compile time behavior. Deactivating for now and reevaluate if the performance impact is significant.