### PR TITLE
recompile stub for HotSpotNativeFunctionHandle if it was invalidated

### DIFF
--- a/graal/com.oracle.graal.truffle.hotspot/src/com/oracle/graal/truffle/hotspot/nfi/HotSpotNativeFunctionInterface.java
+++ b/graal/com.oracle.graal.truffle.hotspot/src/com/oracle/graal/truffle/hotspot/nfi/HotSpotNativeFunctionInterface.java
@@ -138,7 +138,7 @@ public class HotSpotNativeFunctionInterface implements NativeFunctionInterface {
     private HotSpotNativeFunctionHandle createHandle(NativeFunctionPointer functionPointer, Class<?> returnType, Class<?>... argumentTypes) {
         HotSpotNativeFunctionPointer hs = (HotSpotNativeFunctionPointer) functionPointer;
         if (hs != null) {
-            HotSpotNativeFunctionHandle handle = new HotSpotNativeFunctionHandle(hs, returnType, argumentTypes);
+            HotSpotNativeFunctionHandle handle = new HotSpotNativeFunctionHandle(graphBuilder, hs, returnType, argumentTypes);
             graphBuilder.installNativeFunctionStub(handle);
             return handle;
         } else {


### PR DESCRIPTION
This fixes test failures such as:
```
5) test1(com.oracle.nfi.test.NativeFunctionInterfaceTest)
jdk.vm.ci.common.JVMCIError: should not reach here: Execution of GNFI Callstub failed: os::dll_lookup
        at jdk.vm.ci.common.JVMCIError.shouldNotReachHere(JVMCIError.java:49)
        at com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionHandle.call(HotSpotNativeFunctionHandle.java:95)
        at com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionInterface.lookupFunctionPointer(HotSpotNativeFunctionInterface.java:117)
        at com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionInterface.getFunctionHandle(HotSpotNativeFunctionInterface.java:81)
        at com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionInterface.getFunctionHandle(HotSpotNativeFunctionInterface.java:103)
        at com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionInterface.getFunctionHandle(HotSpotNativeFunctionInterface.java:39)
        at com.oracle.nfi.test.NativeFunctionInterfaceTest.test1(NativeFunctionInterfaceTest.java:115)
```