### PR TITLE
Debug.ENABLED should only be true if scoped debugging is in use

### DIFF
--- a/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/Debug.java
+++ b/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/Debug.java
@@ -68,9 +68,6 @@ public class Debug {
         for (DebugInitializationParticipant p : Services.load(DebugInitializationParticipant.class)) {
             p.apply(params);
         }
-        if (!params.enable && (params.enableUnscopedMetrics || params.enableUnscopedTimers || params.enableUnscopedMemUseTrackers)) {
-            params.enable = true;
-        }
     }
 
     /**


### PR DESCRIPTION
When removing use of the `jvmci.debug.enable` system property for initializing `Debug.ENABLED`, other options were [consulted](https://github.com/graalvm/graal-core/commit/57c9f29606b26d76a6817abaa5a7157409ca8131#diff-44907a377a861a8893470d53ce06270dR71) that shouldn't have been.

This addresses the regression in certain Graal compilation time benchmarks since the above commit was made on Jan 11.