### PR TITLE
Make OptimizedCallTarget#log static.

### DIFF
--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/OptimizedCallTarget.java
@@ -135,7 +135,7 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         return (GraalTruffleRuntime) Truffle.getRuntime();
     }
 
-    public final void log(String message) {
+    public static final void log(String message) {
         runtime().log(message);
     }
 
@@ -450,7 +450,7 @@ public class OptimizedCallTarget extends InstalledCode implements RootCallTarget
         }
     }
 
-    private void printException(Throwable e) {
+    private static void printException(Throwable e) {
         StringWriter string = new StringWriter();
         e.printStackTrace(new PrintWriter(string));
         log(string.toString());

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
@@ -551,6 +551,6 @@ public class PartialEvaluator {
     }
 
     private static void logPerformanceWarning(OptimizedCallTarget target, String msg, String details, Map<String, Object> properties) {
-        AbstractDebugCompilationListener.log(target, 0, msg, String.format("%-60s|%s", target, details), properties);
+        AbstractDebugCompilationListener.log(0, msg, String.format("%-60s|%s", target, details), properties);
     }
 }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/AbstractDebugCompilationListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/AbstractDebugCompilationListener.java
@@ -67,7 +67,7 @@ public abstract class AbstractDebugCompilationListener implements GraalTruffleCo
     public void notifyStartup(GraalTruffleRuntime runtime) {
     }
 
-    public static void log(OptimizedCallTarget target, int indent, String msg, String details, Map<String, Object> properties) {
+    public static void log(int indent, String msg, String details, Map<String, Object> properties) {
         int spaceIndent = indent * 2;
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("[truffle] %-16s ", msg));
@@ -97,7 +97,7 @@ public abstract class AbstractDebugCompilationListener implements GraalTruffleCo
                 sb.append(String.format(" %" + length + "s ", propertyBuilder.toString()));
             }
         }
-        target.log(sb.toString());
+        OptimizedCallTarget.log(sb.toString());
     }
 
     public static void addASTSizeProperty(OptimizedCallTarget target, Map<String, Object> properties) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/HistogramInlineInvokePlugin.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/HistogramInlineInvokePlugin.java
@@ -89,12 +89,12 @@ public class HistogramInlineInvokePlugin implements InlineInvokePlugin {
     }
 
     public void print(OptimizedCallTarget target) {
-        target.log(String.format("Truffle expansion histogram for %s", target));
-        target.log("  Invocations = Number of expanded invocations");
-        target.log("  Nodes = Number of non-trival Graal nodes created for this method during partial evaluation.");
-        target.log("  Calls = Number of not expanded calls created for this method during partial evaluation.");
-        target.log(String.format(" %-11s |Nodes %5s %5s %5s %8s |Calls %5s %5s %5s %8s | Method Name", "Invocations", "Sum", "Min", "Max", "Avg", "Sum", "Min", "Max", "Avg"));
-        histogram.values().stream().filter(statistics -> statistics.shallowCount.getSum() > 0).sorted().forEach(statistics -> statistics.print(target));
+        OptimizedCallTarget.log(String.format("Truffle expansion histogram for %s", target));
+        OptimizedCallTarget.log("  Invocations = Number of expanded invocations");
+        OptimizedCallTarget.log("  Nodes = Number of non-trival Graal nodes created for this method during partial evaluation.");
+        OptimizedCallTarget.log("  Calls = Number of not expanded calls created for this method during partial evaluation.");
+        OptimizedCallTarget.log(String.format(" %-11s |Nodes %5s %5s %5s %8s |Calls %5s %5s %5s %8s | Method Name", "Invocations", "Sum", "Min", "Max", "Avg", "Sum", "Min", "Max", "Avg"));
+        histogram.values().stream().filter(statistics -> statistics.shallowCount.getSum() > 0).sorted().forEach(statistics -> statistics.print());
     }
 
     private static class MethodStatistics implements Comparable<MethodStatistics> {
@@ -109,8 +109,8 @@ public class HistogramInlineInvokePlugin implements InlineInvokePlugin {
             this.method = method;
         }
 
-        public void print(OptimizedCallTarget target) {
-            target.log(String.format(" %11d |      %5d %5d %5d %8.2f |      %5d %5d %5d %8.2f | %s", //
+        public void print() {
+            OptimizedCallTarget.log(String.format(" %11d |      %5d %5d %5d %8.2f |      %5d %5d %5d %8.2f | %s", //
                             count, shallowCount.getSum(), shallowCount.getMin(), shallowCount.getMax(), //
                             shallowCount.getAverage(), callCount.getSum(), callCount.getMin(), callCount.getMax(), //
                             callCount.getAverage(), method.format("%h.%n(%p)")));

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationASTListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationASTListener.java
@@ -46,7 +46,7 @@ public final class TraceCompilationASTListener extends AbstractDebugCompilationL
 
     @Override
     public void notifyCompilationSuccess(OptimizedCallTarget target, StructuredGraph graph, CompilationResult result) {
-        log(target, 0, "opt AST", target.toString(), target.getDebugProperties());
+        log(0, "opt AST", target.toString(), target.getDebugProperties());
         printCompactTree(target);
     }
 
@@ -65,7 +65,7 @@ public final class TraceCompilationASTListener extends AbstractDebugCompilationL
                 Node parent = node.getParent();
 
                 if (parent == null) {
-                    target.log(String.format("%s%s", indent, node.getClass().getSimpleName()));
+                    OptimizedCallTarget.log(String.format("%s%s", indent, node.getClass().getSimpleName()));
                 } else {
                     String fieldName = "unknownField";
                     NodeFieldAccessor[] fields = NodeClass.get(parent).getFields();
@@ -85,7 +85,7 @@ public final class TraceCompilationASTListener extends AbstractDebugCompilationL
                             }
                         }
                     }
-                    target.log(String.format("%s%s = %s", indent, fieldName, node.getClass().getSimpleName()));
+                    OptimizedCallTarget.log(String.format("%s%s = %s", indent, fieldName, node.getClass().getSimpleName()));
                 }
                 return true;
             }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationCallTreeListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationCallTreeListener.java
@@ -52,7 +52,7 @@ public final class TraceCompilationCallTreeListener extends AbstractDebugCompila
 
     @Override
     public void notifyCompilationSuccess(OptimizedCallTarget target, StructuredGraph graph, CompilationResult result) {
-        log(target, 0, "opt call tree", target.toString(), target.getDebugProperties());
+        log(0, "opt call tree", target.toString(), target.getDebugProperties());
         logTruffleCallTree(target);
     }
 
@@ -71,10 +71,10 @@ public final class TraceCompilationCallTreeListener extends AbstractDebugCompila
                     Map<String, Object> properties = new LinkedHashMap<>();
                     addASTSizeProperty(callNode.getCurrentCallTarget(), properties);
                     properties.putAll(callNode.getCurrentCallTarget().getDebugProperties());
-                    log(compilable, depth, "opt call tree", callNode.getCurrentCallTarget().toString() + dispatched, properties);
+                    log(depth, "opt call tree", callNode.getCurrentCallTarget().toString() + dispatched, properties);
                 } else if (node instanceof OptimizedIndirectCallNode) {
                     int depth = decisionStack == null ? 0 : decisionStack.size() - 1;
-                    log(compilable, depth, "opt call tree", "<indirect>", new LinkedHashMap<String, Object>());
+                    log(depth, "opt call tree", "<indirect>", new LinkedHashMap<String, Object>());
                 }
                 return true;
             }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationFailureListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationFailureListener.java
@@ -47,7 +47,7 @@ public final class TraceCompilationFailureListener extends AbstractDebugCompilat
         if (isPermanentBailout(t) || PrintBailout.getValue()) {
             Map<String, Object> properties = new LinkedHashMap<>();
             properties.put("Reason", t.toString());
-            log(target, 0, "opt fail", target.toString(), properties);
+            log(0, "opt fail", target.toString(), properties);
         }
     }
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationListener.java
@@ -52,7 +52,7 @@ public final class TraceCompilationListener extends AbstractDebugCompilationList
     @Override
     public void notifyCompilationQueued(OptimizedCallTarget target) {
         if (TraceTruffleCompilationDetails.getValue()) {
-            log(target, 0, "opt queued", target.toString(), target.getDebugProperties());
+            log(0, "opt queued", target.toString(), target.getDebugProperties());
         }
     }
 
@@ -62,7 +62,7 @@ public final class TraceCompilationListener extends AbstractDebugCompilationList
             Map<String, Object> properties = new LinkedHashMap<>();
             addSourceInfo(properties, source);
             properties.put("Reason", reason);
-            log(target, 0, "opt unqueued", target.toString(), properties);
+            log(0, "opt unqueued", target.toString(), properties);
         }
     }
 
@@ -78,7 +78,7 @@ public final class TraceCompilationListener extends AbstractDebugCompilationList
     @Override
     public void notifyCompilationStarted(OptimizedCallTarget target) {
         if (TraceTruffleCompilationDetails.getValue()) {
-            log(target, 0, "opt start", target.toString(), target.getDebugProperties());
+            log(0, "opt start", target.toString(), target.getDebugProperties());
         }
         LocalCompilation compilation = new LocalCompilation();
         compilation.timeCompilationStarted = System.nanoTime();
@@ -122,7 +122,7 @@ public final class TraceCompilationListener extends AbstractDebugCompilationList
         properties.put("CodeSize", result.getTargetCodeSize());
         properties.put("Source", formatSourceSection(target.getRootNode().getSourceSection()));
 
-        log(target, 0, "opt done", target.toString(), properties);
+        log(0, "opt done", target.toString(), properties);
         super.notifyCompilationSuccess(target, graph, result);
         currentCompilation.set(null);
     }
@@ -136,7 +136,7 @@ public final class TraceCompilationListener extends AbstractDebugCompilationList
         Map<String, Object> properties = new LinkedHashMap<>();
         addSourceInfo(properties, source);
         properties.put("Reason", reason);
-        log(target, 0, "opt invalidated", target.toString(), properties);
+        log(0, "opt invalidated", target.toString(), properties);
     }
 
     private static void addSourceInfo(Map<String, Object> properties, Object source) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationPolymorphismListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceCompilationPolymorphismListener.java
@@ -55,7 +55,7 @@ public final class TraceCompilationPolymorphismListener extends AbstractDebugCom
             props.put("simpleName", node.getClass().getSimpleName());
             props.put("subtree", "\n" + NodeUtil.printCompactTreeToString(node));
             String msg = cost == NodeCost.MEGAMORPHIC ? "megamorphic" : "polymorphic";
-            log(target, 0, msg, node.toString(), props);
+            log(0, msg, node.toString(), props);
         });
     }
 

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceInliningListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceInliningListener.java
@@ -49,9 +49,9 @@ public final class TraceInliningListener extends AbstractDebugCompilationListene
             return;
         }
 
-        log(target, 0, "inline start", target.toString(), target.getDebugProperties());
+        log(0, "inline start", target.toString(), target.getDebugProperties());
         logInliningDecisionRecursive(target, inlining, 1);
-        log(target, 0, "inline done", target.toString(), target.getDebugProperties());
+        log(0, "inline done", target.toString(), target.getDebugProperties());
     }
 
     private void logInliningDecisionRecursive(OptimizedCallTarget target, TruffleInlining result, int depth) {
@@ -59,7 +59,7 @@ public final class TraceInliningListener extends AbstractDebugCompilationListene
             TruffleInliningProfile profile = decision.getProfile();
             boolean inlined = decision.isInline();
             String msg = inlined ? "inline success" : "inline failed";
-            log(target, depth, msg, decision.getProfile().getCallNode().getCurrentCallTarget().toString(), profile.getDebugProperties());
+            log(depth, msg, decision.getProfile().getCallNode().getCurrentCallTarget().toString(), profile.getDebugProperties());
             if (inlined) {
                 logInliningDecisionRecursive(target, decision, depth + 1);
             }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceSplittingListener.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/debug/TraceSplittingListener.java
@@ -45,7 +45,7 @@ public final class TraceSplittingListener extends AbstractDebugCompilationListen
     public void notifyCompilationSplit(OptimizedDirectCallNode callNode) {
         OptimizedCallTarget callTarget = callNode.getCallTarget();
         String label = String.format("split %3s-%-4s-%-4s ", splitCount++, callNode.getCurrentCallTarget().getCloneIndex(), callNode.getCallCount());
-        log(callTarget, 0, label, callTarget.toString(), callTarget.getDebugProperties());
+        log(0, label, callTarget.toString(), callTarget.getDebugProperties());
     }
 
 }


### PR DESCRIPTION
This fixes an eclipse 4.5.2 warning which was introduce by #135.