### PR TITLE
Improve AddNode/MulNode input swapping.

### DIFF
--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/ValueNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/ValueNode.java
@@ -32,6 +32,7 @@ import com.oracle.graal.graph.NodeClass;
 import com.oracle.graal.graph.iterators.NodePredicate;
 import com.oracle.graal.nodeinfo.InputType;
 import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.spi.NodeValueMap;
 
 /**
  * This class represents a value within the graph, including local variables, phis, and all other
@@ -161,4 +162,21 @@ public abstract class ValueNode extends com.oracle.graal.graph.Node {
             return super.isAllowedUsageType(type);
         }
     }
+
+    /**
+     * Checks if this node has usages other than the given node {@code node}.
+     *
+     * @param node node which is ignored when searching for usages
+     * @param nodeValueMap
+     * @return true if this node has other usages, false otherwise
+     */
+    public boolean hasUsagesOtherThan(ValueNode node, NodeValueMap nodeValueMap) {
+        for (Node usage : usages()) {
+            if (usage != node && usage instanceof ValueNode && nodeValueMap.hasOperand(usage)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/AddNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/AddNode.java
@@ -22,9 +22,6 @@
  */
 package com.oracle.graal.nodes.calc;
 
-import jdk.vm.ci.meta.Constant;
-import jdk.vm.ci.meta.Value;
-
 import com.oracle.graal.compiler.common.type.ArithmeticOpTable;
 import com.oracle.graal.compiler.common.type.ArithmeticOpTable.BinaryOp;
 import com.oracle.graal.compiler.common.type.ArithmeticOpTable.BinaryOp.Add;
@@ -37,6 +34,9 @@ import com.oracle.graal.nodeinfo.NodeInfo;
 import com.oracle.graal.nodes.ConstantNode;
 import com.oracle.graal.nodes.ValueNode;
 import com.oracle.graal.nodes.spi.NodeLIRBuilderTool;
+
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.Value;
 
 @NodeInfo(shortName = "+")
 public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArithmeticNode, BinaryCommutative<ValueNode> {
@@ -116,7 +116,7 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
         Value op1 = nodeValueMap.operand(getX());
         assert op1 != null : getX() + ", this=" + this;
         Value op2 = nodeValueMap.operand(getY());
-        if (!getY().isConstant() && !BinaryArithmeticNode.livesLonger(this, getY(), nodeValueMap)) {
+        if (shouldSwapInputs(nodeValueMap)) {
             Value tmp = op1;
             op1 = op2;
             op2 = tmp;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/MulNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/calc/MulNode.java
@@ -100,7 +100,7 @@ public class MulNode extends BinaryArithmeticNode<Mul> implements NarrowableArit
     public void generate(NodeLIRBuilderTool nodeValueMap, ArithmeticLIRGeneratorTool gen) {
         Value op1 = nodeValueMap.operand(getX());
         Value op2 = nodeValueMap.operand(getY());
-        if (!getY().isConstant() && !BinaryArithmeticNode.livesLonger(this, getY(), nodeValueMap)) {
+        if (shouldSwapInputs(nodeValueMap)) {
             Value tmp = op1;
             op1 = op2;
             op2 = tmp;


### PR DESCRIPTION
While looking at the micro-benchmarks of https://bugs.openjdk.java.net/browse/JDK-8074124 I noticed that Graal generated a useless move in a very tight loop:

```
  0x000000011c8a3fd9: movzwl 0x10(%r10,%r8,2),%ecx
  0x000000011c8a3fdf: add    %r9d,%ecx
  0x000000011c8a3fe2: inc    %r8d
  0x000000011c8a3fe5: mov    %ecx,%r9d          ;*iload_2 {reexecute=0 rethrow=0 return_oop=0}
                                                ; - org.openjdk.UnsafeConvBench::plain@4 (line 210)

  0x000000011c8a3fe8: cmp    %r8d,%eax
  0x000000011c8a3feb: jg     0x000000011c8a3fd0  ;*ireturn {reexecute=0 rethrow=0 return_oop=0}
                                                ; - org.openjdk.UnsafeConvBench::plain@28 (line 213)
```

It turned out the logic in `AddNode.generate` swapped the inputs solely based on the property if `y` was dead.  In this case both inputs are dead but one of them is an induction variable phi.  This patch takes that into consideration.  Now the loop looks like this:

```
  0x000000010e3bb9d9: movzwl 0x10(%r10,%r8,2),%ecx
  0x000000010e3bb9df: add    %ecx,%r9d
  0x000000010e3bb9e2: inc    %r8d               ;*iload_2 {reexecute=0 rethrow=0 return_oop=0}
                                                ; - org.openjdk.UnsafeConvBench::plain@4 (line 210)

  0x000000010e3bb9e5: cmp    %r8d,%eax
  0x000000010e3bb9e8: jg     0x000000010e3bb9d0  ;*ireturn {reexecute=0 rethrow=0 return_oop=0}
                                                ; - org.openjdk.UnsafeConvBench::plain@28 (line 213)
```