### PR TITLE
Update jvmci import.

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/ClassCastExceptionStub.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/ClassCastExceptionStub.java
@@ -22,8 +22,6 @@
  */
 package com.oracle.graal.hotspot.stubs;
 
-import static com.oracle.graal.replacements.nodes.CStringConstant.cstring;
-
 import com.oracle.graal.hotspot.HotSpotForeignCallLinkage;
 import com.oracle.graal.hotspot.meta.HotSpotProviders;
 import com.oracle.graal.hotspot.replacements.HotSpotReplacementsUtil;
@@ -51,6 +49,6 @@ public class ClassCastExceptionStub extends CreateExceptionStub {
     @Snippet
     private static Object createClassCastException(Object object, KlassPointer targetKlass, @ConstantParameter Register threadRegister) {
         KlassPointer objKlass = HotSpotReplacementsUtil.loadHub(object);
-        return createException(threadRegister, ClassCastException.class, objKlass, cstring(" cannot be cast to "), targetKlass);
+        return createException(threadRegister, ClassCastException.class, objKlass, targetKlass);
     }
 }

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/CreateExceptionStub.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/CreateExceptionStub.java
@@ -71,9 +71,9 @@ public class CreateExceptionStub extends SnippetStub {
         return clearPendingException(thread);
     }
 
-    protected static Object createException(Register threadRegister, Class<? extends Throwable> exception, KlassPointer objKlass, Word message, KlassPointer targetKlass) {
+    protected static Object createException(Register threadRegister, Class<? extends Throwable> exception, KlassPointer objKlass, KlassPointer targetKlass) {
         Word thread = registerAsWord(threadRegister);
-        throwClassCastException(THROW_CLASS_CAST_EXCEPTION, thread, vmSymbol(exception), objKlass, targetKlass, message);
+        throwClassCastException(THROW_CLASS_CAST_EXCEPTION, thread, vmSymbol(exception), objKlass, targetKlass);
         return clearPendingException(thread);
     }
 
@@ -81,7 +81,7 @@ public class CreateExceptionStub extends SnippetStub {
     private static final ForeignCallDescriptor THROW_KLASS_EXTERNAL_NAME_EXCEPTION = new ForeignCallDescriptor("throw_klass_external_name_exception", void.class, Word.class, SymbolPointer.class,
                     KlassPointer.class);
     private static final ForeignCallDescriptor THROW_CLASS_CAST_EXCEPTION = new ForeignCallDescriptor("throw_class_cast_exception", void.class, Word.class, SymbolPointer.class, KlassPointer.class,
-                    KlassPointer.class, Word.class);
+                    KlassPointer.class);
 
     @NodeIntrinsic(StubForeignCallNode.class)
     private static native void throwAndPostJvmtiException(@ConstantNodeParameter ForeignCallDescriptor d, Word thread, SymbolPointer type, Word message);
@@ -90,7 +90,7 @@ public class CreateExceptionStub extends SnippetStub {
     private static native void throwKlassExternalNameException(@ConstantNodeParameter ForeignCallDescriptor d, Word thread, SymbolPointer type, KlassPointer klass);
 
     @NodeIntrinsic(StubForeignCallNode.class)
-    private static native void throwClassCastException(@ConstantNodeParameter ForeignCallDescriptor d, Word thread, SymbolPointer type, KlassPointer objKlass, KlassPointer targetKlass, Word desc);
+    private static native void throwClassCastException(@ConstantNodeParameter ForeignCallDescriptor d, Word thread, SymbolPointer type, KlassPointer objKlass, KlassPointer targetKlass);
 
     public static void registerForeignCalls(HotSpotVMConfig c, HotSpotForeignCallsProviderImpl foreignCalls) {
         foreignCalls.registerForeignCall(THROW_AND_POST_JVMTI_EXCEPTION, c.throwAndPostJvmtiExceptionAddress, NativeCall, DESTROYS_REGISTERS, SAFEPOINT, REEXECUTABLE, any());

--- a/mx.graal-core/suite.py
+++ b/mx.graal-core/suite.py
@@ -39,7 +39,7 @@ suite = {
             {
                "name" : "jvmci",
                "optional" : "true",
-               "version" : "e0a15983ab5113cb433d9b3d74f901354549e423",
+               "version" : "62804a7d3877709d4d421650a6471a15f0d2cec6",
                "urls" : [
                     {"url" : "http://lafo.ssw.uni-linz.ac.at/hg/graal-jvmci-8", "kind" : "hg"},
                     {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},


### PR DESCRIPTION
Remove the `desc` argument from JVMCIRuntime::throw_class_cast_exception.

This is in preparation for running on jdk9 with jigsaw, where the argument disappeared from `SharedRuntime::generate_class_cast_message`. Since it's an optional argument in jdk8, it's easy to stay compatible by just removing it, and we were always passing the default value anyway.