### PR TITLE
AFTER_EXCEPTION_BCI should have no locals live

### DIFF
--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GraalCompilerTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GraalCompilerTest.java
@@ -83,6 +83,7 @@ import com.oracle.graal.lir.phases.LIRSuites;
 import com.oracle.graal.nodeinfo.Verbosity;
 import com.oracle.graal.nodes.BreakpointNode;
 import com.oracle.graal.nodes.ConstantNode;
+import com.oracle.graal.nodes.FrameState;
 import com.oracle.graal.nodes.InfopointNode;
 import com.oracle.graal.nodes.ProxyNode;
 import com.oracle.graal.nodes.ReturnNode;
@@ -381,7 +382,7 @@ public abstract class GraalCompilerTest extends GraalTest {
                     if (!excludeVirtual || !(node instanceof VirtualObjectNode || node instanceof ProxyNode || node instanceof InfopointNode)) {
                         if (node instanceof ConstantNode) {
                             String name = checkConstants ? node.toString(Verbosity.Name) : node.getClass().getSimpleName();
-                            String str = name + (excludeVirtual ? "\n" : "    (" + node.getUsageCount() + ")\n");
+                            String str = name + (excludeVirtual ? "\n" : "    (" + filteredUsageCount(node) + ")\n");
                             constantsLines.add(str);
                         } else {
                             int id;
@@ -392,7 +393,7 @@ public abstract class GraalCompilerTest extends GraalTest {
                                 canonicalId.set(node, id);
                             }
                             String name = node.getClass().getSimpleName();
-                            String str = "  " + id + "|" + name + (excludeVirtual ? "\n" : "    (" + node.getUsageCount() + ")\n");
+                            String str = "  " + id + "|" + name + (excludeVirtual ? "\n" : "    (" + filteredUsageCount(node) + ")\n");
                             result.append(str);
                         }
                     }
@@ -409,6 +410,13 @@ public abstract class GraalCompilerTest extends GraalTest {
         }
 
         return constantsLines.toString() + result.toString();
+    }
+
+    /**
+     * @return usage count excluding {@link FrameState} usages
+     */
+    private static int filteredUsageCount(Node node) {
+        return node.usages().filter(n -> !(n instanceof FrameState)).count();
     }
 
     /**

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -1929,6 +1929,7 @@ public class BytecodeParser implements GraphBuilderContext {
                     }
                     lastLoopExit = loopExit;
                     Debug.log("Target %s Exits %s, scanning framestates...", targetBlock, loop);
+                    newState.clearNonLiveLocals(targetBlock, liveness, true);
                     newState.insertLoopProxies(loopExit, getEntryState(loop));
                     loopExit.setStateAfter(newState.create(bci, loopExit));
                 }

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/FrameStateBuilder.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/FrameStateBuilder.java
@@ -290,6 +290,10 @@ public final class FrameStateBuilder implements SideEffectsState {
             stackSize = stackSizeToRestore;
             return res;
         } else {
+            if (bci == BytecodeFrame.AFTER_EXCEPTION_BCI) {
+                assert outerFrameState == null;
+                clearLocals();
+            }
             return graph.add(new FrameState(outerFrameState, method, bci, locals, stack, stackSize, lockedObjects, Arrays.asList(monitorIds), rethrowException, duringCall));
         }
     }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/FrameState.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/FrameState.java
@@ -143,6 +143,15 @@ public final class FrameState extends VirtualState implements IterableNodeType {
         }
     }
 
+    private void verifyAfterExceptionState() {
+        if (this.bci == BytecodeFrame.AFTER_EXCEPTION_BCI) {
+            assert this.outerFrameState == null;
+            for (int i = 0; i < this.localsSize; i++) {
+                assertTrue(this.values.get(i) == null, "locals should be null in AFTER_EXCEPTION_BCI state");
+            }
+        }
+    }
+
     public FrameState(int bci) {
         this(null, null, bci, 0, 0, 0, false, false, null, Collections.<EscapeObjectState> emptyList());
         assert bci == BytecodeFrame.BEFORE_BCI || bci == BytecodeFrame.AFTER_BCI || bci == BytecodeFrame.AFTER_EXCEPTION_BCI || bci == BytecodeFrame.UNKNOWN_BCI ||
@@ -558,6 +567,7 @@ public final class FrameState extends VirtualState implements IterableNodeType {
             assertTrue(value == null || !value.isDeleted(), "frame state must not contain deleted nodes");
             assertTrue(value == null || value instanceof VirtualObjectNode || (value.getStackKind() != JavaKind.Void), "unexpected value: %s", value);
         }
+        verifyAfterExceptionState();
         return super.verify();
     }
 


### PR DESCRIPTION
This fixes the AFTER_EXCEPTION_BCI problems we were seeing with lucene.  It was mainly the missing clearNonLiveLocals for the merge that was causing the values to leak downwards and appear to be live but I also cleared the AFTER_EXCEPTION_BCI state.  We may want to ensure that PEA doesn't move past AFTER_EXCEPTION_BCI but I couldn't figure out a simple way to do that.  Or at least my attempt to do that failed in a mysterious way.  @dougxc @rschatz @christhalinger 