### PR TITLE
Rationalize dump levels and change default to 1

### DIFF
--- a/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/TraceStatisticsPrinter.java
+++ b/graal/com.oracle.graal.compiler.common/src/com/oracle/graal/compiler/common/alloc/TraceStatisticsPrinter.java
@@ -31,12 +31,11 @@ import com.oracle.graal.debug.Indent;
 
 public final class TraceStatisticsPrinter {
     private static final String SEP = ";";
-    private static final int TRACE_DUMP_LEVEL = 3;
 
     @SuppressWarnings("try")
     public static <T extends AbstractBlockBase<T>> void printTraceStatistics(TraceBuilderResult<T> result, String compilationUnitName) {
         try (Scope s = Debug.scope("DumpTraceStatistics")) {
-            if (Debug.isLogEnabled(TRACE_DUMP_LEVEL)) {
+            if (Debug.isLogEnabled(Debug.VERBOSE_LOG_LEVEL)) {
                 print(result, compilationUnitName);
             }
         } catch (Throwable e) {
@@ -49,9 +48,9 @@ public final class TraceStatisticsPrinter {
         List<Trace<T>> traces = result.getTraces();
         int numTraces = traces.size();
 
-        try (Indent indent0 = Debug.logAndIndent(TRACE_DUMP_LEVEL, "<tracestatistics>")) {
-            Debug.log(TRACE_DUMP_LEVEL, "<name>%s</name>", compilationUnitName != null ? compilationUnitName : "null");
-            try (Indent indent1 = Debug.logAndIndent(TRACE_DUMP_LEVEL, "<traces>")) {
+        try (Indent indent0 = Debug.logAndIndent(Debug.VERBOSE_LOG_LEVEL, "<tracestatistics>")) {
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "<name>%s</name>", compilationUnitName != null ? compilationUnitName : "null");
+            try (Indent indent1 = Debug.logAndIndent(Debug.VERBOSE_LOG_LEVEL, "<traces>")) {
                 printRawLine("tracenumber", "total", "min", "max", "numBlocks");
                 for (int i = 0; i < numTraces; i++) {
                     List<T> t = traces.get(i).getBlocks();
@@ -71,14 +70,14 @@ public final class TraceStatisticsPrinter {
                     printLine(i, total, min, max, t.size());
                 }
             }
-            Debug.log(TRACE_DUMP_LEVEL, "</traces>");
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "</traces>");
         }
-        Debug.log(TRACE_DUMP_LEVEL, "</tracestatistics>");
+        Debug.log(Debug.VERBOSE_LOG_LEVEL, "</tracestatistics>");
 
     }
 
     private static void printRawLine(Object tracenr, Object totalTime, Object minProb, Object maxProb, Object numBlocks) {
-        Debug.log(TRACE_DUMP_LEVEL, "%s", String.join(SEP, tracenr.toString(), totalTime.toString(), minProb.toString(), maxProb.toString(), numBlocks.toString()));
+        Debug.log(Debug.VERBOSE_LOG_LEVEL, "%s", String.join(SEP, tracenr.toString(), totalTime.toString(), minProb.toString(), maxProb.toString(), numBlocks.toString()));
     }
 
     private static void printLine(int tracenr, double totalTime, double minProb, double maxProb, int numBlocks) {

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/ConditionalEliminationTestBase.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/ConditionalEliminationTestBase.java
@@ -61,7 +61,7 @@ public class ConditionalEliminationTestBase extends GraalCompilerTest {
     @SuppressWarnings("try")
     protected void testConditionalElimination(String snippet, String referenceSnippet, boolean applyConditionalEliminationOnReference) {
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         PhaseContext context = new PhaseContext(getProviders());
         CanonicalizerPhase canonicalizer1 = new CanonicalizerPhase();
         if (disableSimplification) {

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/DegeneratedLoopsTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/DegeneratedLoopsTest.java
@@ -86,9 +86,9 @@ public class DegeneratedLoopsTest extends GraalCompilerTest {
             HighTierContext context = getDefaultHighTierContext();
             new InliningPhase(new CanonicalizerPhase()).apply(graph, context);
             new CanonicalizerPhase().apply(graph, context);
-            Debug.dump(graph, "Graph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
             StructuredGraph referenceGraph = parseEager(REFERENCE_SNIPPET, AllowAssumptions.YES);
-            Debug.dump(referenceGraph, "ReferenceGraph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, referenceGraph, "ReferenceGraph");
             assertEquals(referenceGraph, graph);
         } catch (Throwable e) {
             throw Debug.handle(e);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/FindUniqueDefaultMethodTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/FindUniqueDefaultMethodTest.java
@@ -142,7 +142,7 @@ public class FindUniqueDefaultMethodTest extends GraalCompilerTest {
         try (Scope s = Debug.scope("InstanceOfTest", getMetaAccess().lookupJavaMethod(getMethod(snippet)))) {
             StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
             compile(graph.method(), graph);
-            Debug.dump(graph, snippet);
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, snippet);
             return graph;
         } catch (Throwable e) {
             throw Debug.handle(e);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/FloatingReadTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/FloatingReadTest.java
@@ -82,7 +82,7 @@ public class FloatingReadTest extends GraphScheduleTest {
                 }
             }
 
-            Debug.dump(graph, "After lowering");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "After lowering");
 
             Assert.assertNotNull(returnNode);
             Assert.assertNotNull(monitorexit);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GraalCompilerTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GraalCompilerTest.java
@@ -300,13 +300,13 @@ public abstract class GraalCompilerTest extends GraalTest {
         String mismatchString = compareGraphStrings(expected, expectedString, graph, actualString);
 
         if (!excludeVirtual && getNodeCountExcludingUnusedConstants(expected) != getNodeCountExcludingUnusedConstants(graph)) {
-            Debug.dump(expected, "Node count not matching - expected");
-            Debug.dump(graph, "Node count not matching - actual");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, expected, "Node count not matching - expected");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Node count not matching - actual");
             Assert.fail("Graphs do not have the same number of nodes: " + expected.getNodeCount() + " vs. " + graph.getNodeCount() + "\n" + mismatchString);
         }
         if (!expectedString.equals(actualString)) {
-            Debug.dump(expected, "mismatching graphs - expected");
-            Debug.dump(graph, "mismatching graphs - actual");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, expected, "mismatching graphs - expected");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "mismatching graphs - actual");
             Assert.fail(mismatchString);
         }
     }

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GuardEliminationCornerCasesTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/GuardEliminationCornerCasesTest.java
@@ -88,7 +88,7 @@ public class GuardEliminationCornerCasesTest extends GraalCompilerTest {
         new ConvertDeoptimizeToGuardPhase().apply(graph, context);
         CanonicalizerPhase canonicalizer = new CanonicalizerPhase();
         new LoweringPhase(canonicalizer, LoweringTool.StandardLoweringStage.HIGH_TIER).apply(graph, context);
-        Debug.dump(graph, "after parsing");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "after parsing");
 
         GuardNode myGuardNode = null;
         for (Node n : graph.getNodes()) {
@@ -109,7 +109,7 @@ public class GuardEliminationCornerCasesTest extends GraalCompilerTest {
         AbstractBeginNode prevBegin = BeginNode.prevBegin((FixedNode) myBegin.predecessor());
         myGuardNode.setAnchor(prevBegin);
 
-        Debug.dump(graph, "after manual modification");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "after manual modification");
         graph.reverseUsageOrder();
         new DominatorConditionalEliminationPhase(true).apply(graph);
         new SchedulePhase(SchedulePhase.SchedulingStrategy.EARLIEST).apply(graph);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/IfCanonicalizerTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/IfCanonicalizerTest.java
@@ -219,7 +219,7 @@ public class IfCanonicalizerTest extends GraalCompilerTest {
                 n.replaceFirstInput(param, constant);
             }
         }
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         new CanonicalizerPhase().apply(graph, new PhaseContext(getProviders()));
         for (FrameState fs : param.usages().filter(FrameState.class).snapshot()) {
             fs.replaceFirstInput(param, null);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/MemoryScheduleTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/MemoryScheduleTest.java
@@ -736,7 +736,7 @@ public class MemoryScheduleTest extends GraphScheduleTest {
                 if (mode == TestMode.WITHOUT_FRAMESTATES || mode == TestMode.INLINED_WITHOUT_FRAMESTATES) {
                     graph.clearAllStateAfter();
                 }
-                Debug.dump(graph, "after removal of framestates");
+                Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "after removal of framestates");
 
                 new FloatingReadPhase().apply(graph);
                 new RemoveValueProxyPhase().apply(graph);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/MergeCanonicalizerTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/MergeCanonicalizerTest.java
@@ -61,7 +61,7 @@ public class MergeCanonicalizerTest extends GraalCompilerTest {
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
         new CanonicalizerPhase().apply(graph, new PhaseContext(getProviders()));
         new CanonicalizerPhase().apply(graph, new PhaseContext(getProviders()));
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         assertDeepEquals(returnCount, graph.getNodes(ReturnNode.TYPE).count());
     }
 }

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/NestedLoopTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/NestedLoopTest.java
@@ -142,7 +142,7 @@ public class NestedLoopTest extends GraalCompilerTest {
 
     private void test(String snippet, int rootExits, int nestedExits, int innerExits) {
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         ControlFlowGraph cfg = ControlFlowGraph.compute(graph, true, true, true, true);
 
         Assert.assertEquals(3, cfg.getLoops().size());
@@ -162,7 +162,7 @@ public class NestedLoopTest extends GraalCompilerTest {
         Assert.assertEquals(rootExits, rootLoop.getExits().size());
         Assert.assertEquals(nestedExits, nestedLoop.getExits().size());
         Assert.assertEquals(innerExits, innerMostLoop.getExits().size());
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
     }
 
     private static boolean contains(Loop<Block> loop, Invoke node, ControlFlowGraph cfg) {

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/PhiCreationTests.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/PhiCreationTests.java
@@ -70,7 +70,7 @@ public class PhiCreationTests extends GraalCompilerTest {
     @Test
     public void test3() {
         StructuredGraph graph = parseEager("test3Snippet", AllowAssumptions.YES);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         Assert.assertFalse(graph.getNodes().filter(ValuePhiNode.class).iterator().hasNext());
     }
 
@@ -86,7 +86,7 @@ public class PhiCreationTests extends GraalCompilerTest {
     @Test
     public void test4() {
         StructuredGraph graph = parseEager("test4Snippet", AllowAssumptions.YES);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         Assert.assertFalse(graph.getNodes().filter(ValuePhiNode.class).iterator().hasNext());
     }
 

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/PushThroughIfTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/PushThroughIfTest.java
@@ -59,7 +59,7 @@ public class PushThroughIfTest extends GraalCompilerTest {
 
     private void test(String snippet, String reference) {
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         for (FrameState fs : graph.getNodes(FrameState.TYPE).snapshot()) {
             fs.replaceAtUsages(null);
             GraphUtil.killWithUnusedFloatingInputs(fs);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/ReadAfterCheckCastTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/ReadAfterCheckCastTest.java
@@ -96,7 +96,7 @@ public class ReadAfterCheckCastTest extends GraphScheduleTest {
             new OptimizeGuardAnchorsPhase().apply(graph);
             canonicalizer.apply(graph, context);
 
-            Debug.dump(graph, "After lowering");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "After lowering");
 
             for (FloatingReadNode node : graph.getNodes(ParameterNode.TYPE).first().usages().filter(FloatingReadNode.class)) {
                 // Checking that the parameter a is not directly used for the access to field

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/ScalarTypeSystemTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/ScalarTypeSystemTest.java
@@ -131,7 +131,7 @@ public class ScalarTypeSystemTest extends GraalCompilerTest {
     private void test(final String snippet, final String referenceSnippet) {
         // No debug scope to reduce console noise for @Test(expected = ...) tests
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.NO);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         PhaseContext context = new PhaseContext(getProviders());
         new CanonicalizerPhase().apply(graph, context);
         StructuredGraph referenceGraph = parseEager(referenceSnippet, AllowAssumptions.NO);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/SchedulingTest2.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/SchedulingTest2.java
@@ -69,7 +69,7 @@ public class SchedulingTest2 extends GraphScheduleTest {
         BeginNode beginNode = graph.add(new BeginNode());
         returnNode.replaceAtPredecessor(beginNode);
         beginNode.setNext(returnNode);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         SchedulePhase schedulePhase = new SchedulePhase(SchedulingStrategy.EARLIEST);
         schedulePhase.apply(graph);
         ScheduleResult schedule = graph.getLastSchedule();

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/SimpleCFGTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/SimpleCFGTest.java
@@ -41,7 +41,7 @@ import com.oracle.graal.nodes.cfg.ControlFlowGraph;
 public class SimpleCFGTest extends GraalCompilerTest {
 
     private static void dumpGraph(final StructuredGraph graph) {
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
     }
 
     @Test

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/StraighteningTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/StraighteningTest.java
@@ -88,7 +88,7 @@ public class StraighteningTest extends GraalCompilerTest {
     private void test(final String snippet) {
         // No debug scope to reduce console noise for @Test(expected = ...) tests
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         new CanonicalizerPhase().apply(graph, new PhaseContext(getProviders()));
         StructuredGraph referenceGraph = parseEager(REFERENCE_SNIPPET, AllowAssumptions.YES);
         assertEquals(referenceGraph, graph);

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/TypeSystemTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/TypeSystemTest.java
@@ -180,7 +180,7 @@ public class TypeSystemTest extends GraalCompilerTest {
 
     private void test(String snippet, String referenceSnippet) {
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.NO);
-        Debug.dump(graph, "Graph");
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
         /*
          * When using FlowSensitiveReductionPhase instead of ConditionalEliminationPhase,
          * tail-duplication gets activated thus resulting in a graph with more nodes than the
@@ -200,8 +200,8 @@ public class TypeSystemTest extends GraalCompilerTest {
     @Override
     protected void assertEquals(StructuredGraph expected, StructuredGraph graph) {
         if (getNodeCountExcludingUnusedConstants(expected) != getNodeCountExcludingUnusedConstants(graph)) {
-            Debug.dump(expected, "expected (node count)");
-            Debug.dump(graph, "graph (node count)");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, expected, "expected (node count)");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "graph (node count)");
             Assert.fail("Graphs do not have the same number of nodes: " + expected.getNodeCount() + " vs. " + graph.getNodeCount());
         }
     }
@@ -244,7 +244,7 @@ public class TypeSystemTest extends GraalCompilerTest {
         StructuredGraph graph = parseEager(snippet, AllowAssumptions.NO);
         new CanonicalizerPhase().apply(graph, new PhaseContext(getProviders()));
         new CanonicalizerPhase().apply(graph, new PhaseContext(getProviders()));
-        Debug.dump(graph, "Graph " + snippet);
+        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph " + snippet);
         Assert.assertFalse("shouldn't have nodes of type " + clazz, graph.getNodes().filter(clazz).iterator().hasNext());
     }
 }

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/VerifyDebugUsageTest.java
@@ -81,7 +81,7 @@ public class VerifyDebugUsageTest {
 
         @Override
         protected void run(StructuredGraph graph) {
-            Debug.dump(graph, "%s", graph.toString());
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "%s", graph.toString());
         }
 
     }
@@ -124,7 +124,7 @@ public class VerifyDebugUsageTest {
 
         @Override
         protected void run(StructuredGraph graph) {
-            Debug.dump(graph, "error " + graph);
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "error " + graph);
         }
 
     }
@@ -167,7 +167,7 @@ public class VerifyDebugUsageTest {
 
         @Override
         protected void run(StructuredGraph graph) {
-            Debug.dump(graph, "%s", graph);
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "%s", graph);
         }
 
     }

--- a/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/inlining/InliningTest.java
+++ b/graal/com.oracle.graal.compiler.test/src/com/oracle/graal/compiler/test/inlining/InliningTest.java
@@ -242,10 +242,10 @@ public class InliningTest extends GraalCompilerTest {
             PhaseSuite<HighTierContext> graphBuilderSuite = eagerInfopointMode ? getCustomGraphBuilderSuite(GraphBuilderConfiguration.getFullDebugDefault(getDefaultGraphBuilderPlugins()))
                             : getDefaultGraphBuilderSuite();
             HighTierContext context = new HighTierContext(getProviders(), graphBuilderSuite, OptimisticOptimizations.ALL);
-            Debug.dump(graph, "Graph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
             new CanonicalizerPhase().apply(graph, context);
             new InliningPhase(new CanonicalizerPhase()).apply(graph, context);
-            Debug.dump(graph, "Graph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
             new CanonicalizerPhase().apply(graph, context);
             new DeadCodeEliminationPhase().apply(graph);
             return graph;

--- a/graal/com.oracle.graal.compiler/src/com/oracle/graal/compiler/GraalCompiler.java
+++ b/graal/com.oracle.graal.compiler/src/com/oracle/graal/compiler/GraalCompiler.java
@@ -191,7 +191,7 @@ public class GraalCompiler {
                 }
                 new DeadCodeEliminationPhase(Optional).apply(graph);
             } else {
-                Debug.dump(graph, "initial state");
+                Debug.dump(Debug.INFO_LOG_LEVEL, graph, "initial state");
             }
 
             suites.getHighTier().apply(graph, highTierContext);
@@ -204,7 +204,7 @@ public class GraalCompiler {
             LowTierContext lowTierContext = new LowTierContext(providers, target);
             suites.getLowTier().apply(graph, lowTierContext);
 
-            Debug.dump(graph.getLastSchedule(), "Final HIR schedule");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph.getLastSchedule(), "Final HIR schedule");
         } catch (Throwable e) {
             throw Debug.handle(e);
         }
@@ -274,7 +274,7 @@ public class GraalCompiler {
                 linearScanOrder = ComputeBlockOrder.computeLinearScanOrder(blocks.length, startBlock);
 
                 lir = new LIR(schedule.getCFG(), linearScanOrder, codeEmittingOrder);
-                Debug.dump(lir, "After linear scan order");
+                Debug.dump(Debug.INFO_LOG_LEVEL, lir, "After linear scan order");
             } catch (Throwable e) {
                 throw Debug.handle(e);
             }
@@ -293,9 +293,9 @@ public class GraalCompiler {
             }
 
             try (Scope s = Debug.scope("LIRStages", nodeLirGen, lir)) {
-                Debug.dump(1, lir, "After LIR generation");
+                Debug.dump(Debug.BASIC_LOG_LEVEL, lir, "After LIR generation");
                 LIRGenerationResult result = emitLowLevel(backend.getTarget(), codeEmittingOrder, linearScanOrder, lirGenRes, lirGen, lirSuites, backend.newRegisterAllocationConfig(registerConfig));
-                Debug.dump(1, lir, "Before code generation");
+                Debug.dump(Debug.BASIC_LOG_LEVEL, lir, "Before code generation");
                 return result;
             } catch (Throwable e) {
                 throw Debug.handle(e);
@@ -371,7 +371,7 @@ public class GraalCompiler {
                 Debug.metric("ExceptionHandlersEmitted").add(compilationResult.getExceptionHandlers().size());
             }
 
-            Debug.dump(1, compilationResult, "After code generation");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, compilationResult, "After code generation");
         }
     }
 }

--- a/graal/com.oracle.graal.compiler/src/com/oracle/graal/compiler/phases/GraphChangeMonitoringPhase.java
+++ b/graal/com.oracle.graal.compiler/src/com/oracle/graal/compiler/phases/GraphChangeMonitoringPhase.java
@@ -86,13 +86,13 @@ public class GraphChangeMonitoringPhase<C extends PhaseContext> extends PhaseSui
             listener = new HashSetNodeEventListener();
             try (NodeEventScope s = graph.trackNodeEvents(listener)) {
                 try (Scope s2 = Debug.scope("WithGraphChangeMonitoring." + getName() + "-" + message)) {
-                    if (Debug.isDumpEnabled(BasePhase.PHASE_DUMP_LEVEL)) {
-                        Debug.dump(BasePhase.PHASE_DUMP_LEVEL, graph, "*** Before phase %s", getName());
+                    if (Debug.isDumpEnabled(Debug.BASIC_LOG_LEVEL)) {
+                        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "*** Before phase %s", getName());
                     }
                     super.run(graph, context);
                     Set<Node> collect = listener.getNodes().stream().filter(e -> !e.isAlive()).filter(e -> !(e instanceof LogicConstantNode)).collect(Collectors.toSet());
-                    if (Debug.isDumpEnabled(BasePhase.PHASE_DUMP_LEVEL)) {
-                        Debug.dump(BasePhase.PHASE_DUMP_LEVEL, graph, "*** After phase %s %s", getName(), collect);
+                    if (Debug.isDumpEnabled(Debug.BASIC_LOG_LEVEL)) {
+                        Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "*** After phase %s %s", getName(), collect);
                     }
                     Debug.log("*** %s %s %s\n", message, graph, collect);
                 }

--- a/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/Debug.java
+++ b/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/Debug.java
@@ -105,11 +105,9 @@ public class Debug {
         return config.isDumpEnabledForMethod();
     }
 
-    public static final int DEFAULT_LOG_LEVEL = 2;
-
-    public static boolean isDumpEnabled() {
-        return isDumpEnabled(DEFAULT_LOG_LEVEL);
-    }
+    public static final int BASIC_LOG_LEVEL = 1;
+    public static final int INFO_LOG_LEVEL = 2;
+    public static final int VERBOSE_LOG_LEVEL = 3;
 
     public static boolean isDumpEnabled(int dumpLevel) {
         return ENABLED && DebugScope.getInstance().isDumpEnabled(dumpLevel);
@@ -166,7 +164,7 @@ public class Debug {
     }
 
     public static boolean isLogEnabled() {
-        return isLogEnabled(DEFAULT_LOG_LEVEL);
+        return isLogEnabled(BASIC_LOG_LEVEL);
     }
 
     public static boolean isLogEnabled(int logLevel) {
@@ -390,7 +388,7 @@ public class Debug {
     }
 
     public static void log(String msg) {
-        log(DEFAULT_LOG_LEVEL, msg);
+        log(BASIC_LOG_LEVEL, msg);
     }
 
     /**
@@ -405,7 +403,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg) {
-        log(DEFAULT_LOG_LEVEL, format, arg);
+        log(BASIC_LOG_LEVEL, format, arg);
     }
 
     /**
@@ -421,7 +419,7 @@ public class Debug {
     }
 
     public static void log(String format, int arg) {
-        log(DEFAULT_LOG_LEVEL, format, arg);
+        log(BASIC_LOG_LEVEL, format, arg);
     }
 
     /**
@@ -437,7 +435,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -450,7 +448,7 @@ public class Debug {
     }
 
     public static void log(String format, int arg1, Object arg2) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -463,7 +461,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, int arg2) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -476,7 +474,7 @@ public class Debug {
     }
 
     public static void log(String format, int arg1, int arg2) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -489,7 +487,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3);
     }
 
     /**
@@ -502,7 +500,7 @@ public class Debug {
     }
 
     public static void log(String format, int arg1, int arg2, int arg3) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3);
     }
 
     /**
@@ -515,7 +513,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4);
     }
 
     /**
@@ -528,7 +526,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5);
     }
 
     /**
@@ -541,7 +539,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
     /**
@@ -554,11 +552,11 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
     /**
@@ -577,7 +575,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
     }
 
     public static void log(int logLevel, String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9) {
@@ -587,7 +585,7 @@ public class Debug {
     }
 
     public static void log(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9, Object arg10) {
-        log(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+        log(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     }
 
     public static void log(int logLevel, String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9, Object arg10) {
@@ -597,7 +595,7 @@ public class Debug {
     }
 
     public static void logv(String format, Object... args) {
-        logv(DEFAULT_LOG_LEVEL, format, args);
+        logv(INFO_LOG_LEVEL, format, args);
     }
 
     /**
@@ -625,7 +623,7 @@ public class Debug {
     @Deprecated
     public static void log(String format, Object[] args) {
         assert false : "shouldn't use this";
-        log(DEFAULT_LOG_LEVEL, format, args);
+        log(BASIC_LOG_LEVEL, format, args);
     }
 
     /**
@@ -640,18 +638,10 @@ public class Debug {
         logv(logLevel, format, args);
     }
 
-    public static void dump(Object object, String msg) {
-        dump(DEFAULT_LOG_LEVEL, object, msg);
-    }
-
     public static void dump(int dumpLevel, Object object, String msg) {
         if (ENABLED && DebugScope.getInstance().isDumpEnabled(dumpLevel)) {
             DebugScope.getInstance().dump(dumpLevel, object, msg);
         }
-    }
-
-    public static void dump(Object object, String format, Object arg) {
-        dump(DEFAULT_LOG_LEVEL, object, format, arg);
     }
 
     public static void dump(int dumpLevel, Object object, String format, Object arg) {
@@ -660,36 +650,16 @@ public class Debug {
         }
     }
 
-    public static void dump(Object object, String format, Object arg1, Object arg2) {
-        dump(DEFAULT_LOG_LEVEL, object, format, arg1, arg2);
-    }
-
     public static void dump(int dumpLevel, Object object, String format, Object arg1, Object arg2) {
         if (ENABLED && DebugScope.getInstance().isDumpEnabled(dumpLevel)) {
             DebugScope.getInstance().dump(dumpLevel, object, format, arg1, arg2);
         }
     }
 
-    public static void dump(Object object, String format, Object arg1, Object arg2, Object arg3) {
-        dump(DEFAULT_LOG_LEVEL, object, format, arg1, arg2, arg3);
-    }
-
     public static void dump(int dumpLevel, Object object, String format, Object arg1, Object arg2, Object arg3) {
         if (ENABLED && DebugScope.getInstance().isDumpEnabled(dumpLevel)) {
             DebugScope.getInstance().dump(dumpLevel, object, format, arg1, arg2, arg3);
         }
-    }
-
-    /**
-     * This override exists to catch cases when {@link #dump(Object, String, Object)} is called with
-     * one argument bound to a varargs method parameter. It will bind to this method instead of the
-     * single arg variant and produce a deprecation warning instead of silently wrapping the
-     * Object[] inside of another Object[].
-     */
-    @Deprecated
-    public static void dump(Object object, String format, Object[] args) {
-        assert false : "shouldn't use this";
-        dump(DEFAULT_LOG_LEVEL, object, format, args);
     }
 
     /**
@@ -769,7 +739,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String msg) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, msg);
+        return logAndIndent(BASIC_LOG_LEVEL, msg);
     }
 
     /**
@@ -787,7 +757,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg);
     }
 
     /**
@@ -806,7 +776,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, int arg) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg);
     }
 
     /**
@@ -825,7 +795,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, int arg1, Object arg2) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -839,7 +809,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, int arg2) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -853,7 +823,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, int arg1, int arg2) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -867,7 +837,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, Object arg2) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2);
     }
 
     /**
@@ -881,7 +851,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, Object arg2, Object arg3) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2, arg3);
     }
 
     /**
@@ -895,7 +865,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, int arg1, int arg2, int arg3) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2, arg3);
     }
 
     /**
@@ -909,7 +879,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, int arg2, int arg3) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2, arg3);
     }
 
     /**
@@ -923,7 +893,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4);
     }
 
     /**
@@ -937,7 +907,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5);
     }
 
     /**
@@ -951,7 +921,7 @@ public class Debug {
     }
 
     public static Indent logAndIndent(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
-        return logAndIndent(DEFAULT_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        return logAndIndent(BASIC_LOG_LEVEL, format, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
     /**
@@ -999,7 +969,7 @@ public class Debug {
     @Deprecated
     public static void logAndIndent(String format, Object[] args) {
         assert false : "shouldn't use this";
-        logAndIndent(DEFAULT_LOG_LEVEL, format, args);
+        logAndIndent(BASIC_LOG_LEVEL, format, args);
     }
 
     /**

--- a/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/DebugFilter.java
+++ b/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/DebugFilter.java
@@ -42,28 +42,28 @@ import com.oracle.graal.debug.internal.DebugScope;
  * {@code  <pattern>} is interpreted as a glob pattern if it contains a "*" or "?" character.
  * Otherwise, it is interpreted as a substring. If {@code <pattern>} is empty, it matches every
  * scope. If {@code :
- * <level>} is omitted, it defaults to {@link Debug#DEFAULT_LOG_LEVEL}. The term {@code ~<pattern>}
- * is a shorthand for {@code <pattern>:0} to disable a debug facility for a pattern.
+ * <level>} is omitted, it defaults to {@link Debug#BASIC_LOG_LEVEL}. The term {@code ~<pattern>} is
+ * a shorthand for {@code <pattern>:0} to disable a debug facility for a pattern.
  * <p>
  * The resulting log level of a scope is determined by the <em>last</em> matching term. If no term
  * matches, the log level is 0 (disabled). A filter with no terms matches every scope with a log
- * level of {@link Debug#DEFAULT_LOG_LEVEL}.
+ * level of {@link Debug#BASIC_LOG_LEVEL}.
  *
  * <h2>Examples of filters</h2>
  *
  * <ul>
  * <li>(empty string)<br>
- * Matches any scope with log level {@link Debug#DEFAULT_LOG_LEVEL}.
+ * Matches any scope with log level {@link Debug#BASIC_LOG_LEVEL}.
  *
  * <li>{@code :1}<br>
  * Matches any scope with log level 1.
  *
  * <li>{@code *}<br>
- * Matches any scope with log level {@link Debug#DEFAULT_LOG_LEVEL}.
+ * Matches any scope with log level {@link Debug#BASIC_LOG_LEVEL}.
  *
  * <li>{@code CodeGen,CodeInstall}<br>
  * Matches scopes containing "CodeGen" or "CodeInstall", both with log level
- * {@link Debug#DEFAULT_LOG_LEVEL}.
+ * {@link Debug#BASIC_LOG_LEVEL}.
  *
  * <li>{@code CodeGen:2,CodeInstall:1}<br>
  * Matches scopes containing "CodeGen" with log level 2, or "CodeInstall" with log level 1.
@@ -75,10 +75,10 @@ import com.oracle.graal.debug.internal.DebugScope;
  * Matches all scopes with log level 1, except those containing "Dead".
  *
  * <li>{@code Code*}<br>
- * Matches scopes starting with "Code" with log level {@link Debug#DEFAULT_LOG_LEVEL}.
+ * Matches scopes starting with "Code" with log level {@link Debug#BASIC_LOG_LEVEL}.
  *
  * <li>{@code Code,~Dead}<br>
- * Matches scopes containing "Code" but not "Dead", with log level {@link Debug#DEFAULT_LOG_LEVEL}.
+ * Matches scopes containing "Code" but not "Dead", with log level {@link Debug#BASIC_LOG_LEVEL}.
  * </ul>
  */
 final class DebugFilter {
@@ -109,14 +109,32 @@ final class DebugFilter {
                         level = 0;
                     } else {
                         pattern = t;
-                        level = Debug.DEFAULT_LOG_LEVEL;
+                        level = Debug.BASIC_LOG_LEVEL;
                     }
                 } else {
                     pattern = t.substring(0, idx);
                     if (idx + 1 < t.length()) {
-                        level = Integer.parseInt(t.substring(idx + 1));
+                        String levelString = t.substring(idx + 1);
+                        try {
+                            level = Integer.parseInt(levelString);
+                        } catch (NumberFormatException e) {
+                            switch (levelString) {
+                                case "basic":
+                                    level = Debug.BASIC_LOG_LEVEL;
+                                    break;
+                                case "info":
+                                    level = Debug.INFO_LOG_LEVEL;
+                                    break;
+                                case "verbose":
+                                    level = Debug.VERBOSE_LOG_LEVEL;
+                                    break;
+                                default:
+                                    throw new IllegalArgumentException("Unknown dump level: \"" + levelString + "\" expected basic, info, verbose or an integer");
+                            }
+                        }
+
                     } else {
-                        level = Debug.DEFAULT_LOG_LEVEL;
+                        level = Debug.BASIC_LOG_LEVEL;
                     }
                 }
 
@@ -130,7 +148,7 @@ final class DebugFilter {
      */
     public int matchLevel(String input) {
         if (terms == null) {
-            return Debug.DEFAULT_LOG_LEVEL;
+            return Debug.BASIC_LOG_LEVEL;
         } else {
             int level = 0;
             for (Term t : terms) {

--- a/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/GraalDebugConfig.java
+++ b/graal/com.oracle.graal.debug/src/com/oracle/graal/debug/GraalDebugConfig.java
@@ -277,14 +277,14 @@ public class GraalDebugConfig implements DebugConfig {
         if (e instanceof BailoutException && !Options.InterceptBailout.getValue()) {
             return null;
         }
-        Debug.setConfig(Debug.fixedConfig(Debug.DEFAULT_LOG_LEVEL, Debug.DEFAULT_LOG_LEVEL, false, false, false, false, dumpHandlers, verifyHandlers, output));
+        Debug.setConfig(Debug.fixedConfig(Debug.BASIC_LOG_LEVEL, Debug.BASIC_LOG_LEVEL, false, false, false, false, dumpHandlers, verifyHandlers, output));
         Debug.log("Exception occurred in scope: %s", Debug.currentScope());
         HashSet<Object> firstSeen = new HashSet<>();
         for (Object o : Debug.context()) {
             // Only dump a context object once.
             if (firstSeen.add(o)) {
                 if (Options.DumpOnError.getValue()) {
-                    Debug.dump(o, "Exception: %s", e);
+                    Debug.dump(Debug.BASIC_LOG_LEVEL, o, "Exception: %s", e);
                 } else {
                     Debug.log("Context obj %s", o);
                 }

--- a/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotLIRGenerator.java
+++ b/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotLIRGenerator.java
@@ -533,7 +533,7 @@ public class AMD64HotSpotLIRGenerator extends AMD64LIRGenerator implements HotSp
             LIR lir = getResult().getLIR();
             List<LIRInstruction> instructions = lir.getLIRforBlock(lir.getControlFlowGraph().getStartBlock());
             instructions.add(1, op);
-            Debug.dump(lir, "created rescue dummy op");
+            Debug.dump(Debug.INFO_LOG_LEVEL, lir, "created rescue dummy op");
         }
     }
 

--- a/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/ClassSubstitutionsTests.java
+++ b/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/ClassSubstitutionsTests.java
@@ -48,7 +48,7 @@ public class ClassSubstitutionsTests extends GraalCompilerTest {
             StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
             compile(graph.method(), graph);
             assertNotInGraph(graph, Invoke.class);
-            Debug.dump(graph, snippet);
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, snippet);
             return graph;
         } catch (Throwable e) {
             throw Debug.handle(e);

--- a/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/ConstantPoolSubstitutionsTests.java
+++ b/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/ConstantPoolSubstitutionsTests.java
@@ -43,7 +43,7 @@ public class ConstantPoolSubstitutionsTests extends GraalCompilerTest {
             StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
             compile(graph.method(), graph);
             assertNotInGraph(graph, Invoke.class);
-            Debug.dump(graph, snippet);
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, snippet);
             return graph;
         } catch (Throwable e) {
             throw Debug.handle(e);

--- a/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/WriteBarrierAdditionTest.java
+++ b/graal/com.oracle.graal.hotspot.test/src/com/oracle/graal/hotspot/test/WriteBarrierAdditionTest.java
@@ -267,7 +267,7 @@ public class WriteBarrierAdditionTest extends HotSpotGraalCompilerTest {
             new GuardLoweringPhase().apply(graph, midContext);
             new LoweringPhase(new CanonicalizerPhase(), LoweringTool.StandardLoweringStage.MID_TIER).apply(graph, midContext);
             new WriteBarrierAdditionPhase(config).apply(graph);
-            Debug.dump(graph, "After Write Barrier Addition");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "After Write Barrier Addition");
 
             int barriers = 0;
             if (config.useG1GC) {

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/HotSpotGraalVMEventListener.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/HotSpotGraalVMEventListener.java
@@ -50,8 +50,8 @@ public class HotSpotGraalVMEventListener implements HotSpotVMEventListener {
 
     @Override
     public void notifyInstall(HotSpotCodeCacheProvider codeCache, InstalledCode installedCode, CompiledCode compiledCode) {
-        if (Debug.isDumpEnabled()) {
-            Debug.dump(new Object[]{compiledCode, installedCode}, "After code installation");
+        if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
+            Debug.dump(Debug.INFO_LOG_LEVEL, new Object[]{compiledCode, installedCode}, "After code installation");
         }
         if (Debug.isLogEnabled()) {
             Debug.log("%s", codeCache.disassemble(installedCode));

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/phases/OnStackReplacementPhase.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/phases/OnStackReplacementPhase.java
@@ -58,7 +58,7 @@ public class OnStackReplacementPhase extends Phase {
             // used.
             return;
         }
-        Debug.dump(graph, "OnStackReplacement initial");
+        Debug.dump(Debug.INFO_LOG_LEVEL, graph, "OnStackReplacement initial");
         EntryMarkerNode osr;
         do {
             NodeIterable<EntryMarkerNode> osrNodes = graph.getNodes(EntryMarkerNode.TYPE);
@@ -94,7 +94,7 @@ public class OnStackReplacementPhase extends Phase {
                 proxy.replaceAndDelete(proxy.value());
             }
             GraphUtil.removeFixedWithUnusedInputs(osr);
-            Debug.dump(graph, "OnStackReplacement loop peeling result");
+            Debug.dump(Debug.INFO_LOG_LEVEL, graph, "OnStackReplacement loop peeling result");
         } while (true);
 
         FrameState osrState = osr.stateAfter();
@@ -125,7 +125,7 @@ public class OnStackReplacementPhase extends Phase {
 
         GraphUtil.killCFG(start);
 
-        Debug.dump(graph, "OnStackReplacement result");
+        Debug.dump(Debug.INFO_LOG_LEVEL, graph, "OnStackReplacement result");
         new DeadCodeEliminationPhase(Required).apply(graph);
     }
 }

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/ForeignCallStub.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/stubs/ForeignCallStub.java
@@ -232,14 +232,14 @@ public class ForeignCallStub extends Stub {
         }
         kit.append(new ReturnNode(linkage.getDescriptor().getResultType() == void.class ? null : result));
 
-        if (Debug.isDumpEnabled()) {
-            Debug.dump(graph, "Initial stub graph");
+        if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
+            Debug.dump(Debug.INFO_LOG_LEVEL, graph, "Initial stub graph");
         }
 
         kit.inlineInvokes();
 
-        if (Debug.isDumpEnabled()) {
-            Debug.dump(graph, "Stub graph before compilation");
+        if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
+            Debug.dump(Debug.INFO_LOG_LEVEL, graph, "Stub graph before compilation");
         }
 
         return graph;

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BciBlockMapping.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BciBlockMapping.java
@@ -1042,8 +1042,8 @@ public final class BciBlockMapping {
     public static BciBlockMapping create(BytecodeStream stream, ResolvedJavaMethod method) {
         BciBlockMapping map = new BciBlockMapping(method);
         map.build(stream);
-        if (Debug.isDumpEnabled()) {
-            Debug.dump(map, method.format("After block building %f %R %H.%n(%P)"));
+        if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
+            Debug.dump(Debug.INFO_LOG_LEVEL, map, method.format("After block building %f %R %H.%n(%P)"));
         }
 
         return map;

--- a/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
+++ b/graal/com.oracle.graal.java/src/com/oracle/graal/java/BytecodeParser.java
@@ -724,8 +724,8 @@ public class BytecodeParser implements GraphBuilderContext {
                 processBlock(block);
             }
 
-            if (Debug.isDumpEnabled() && DumpDuringGraphBuilding.getValue() && this.beforeReturnNode != startInstruction) {
-                Debug.dump(graph, "Bytecodes parsed: %s.%s", method.getDeclaringClass().getUnqualifiedName(), method.getName());
+            if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL) && DumpDuringGraphBuilding.getValue() && this.beforeReturnNode != startInstruction) {
+                Debug.dump(Debug.INFO_LOG_LEVEL, graph, "Bytecodes parsed: %s.%s", method.getDeclaringClass().getUnqualifiedName(), method.getName());
             }
         }
     }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScan.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScan.java
@@ -723,11 +723,11 @@ public class LinearScan {
                 }
             }
         }
-        Debug.dump(1, new LinearScanIntervalDumper(Arrays.copyOf(intervals, intervalsSize)), label);
+        Debug.dump(Debug.BASIC_LOG_LEVEL, new LinearScanIntervalDumper(Arrays.copyOf(intervals, intervalsSize)), label);
     }
 
     public void printLir(String label, @SuppressWarnings("unused") boolean hirValid) {
-        Debug.dump(ir, label);
+        Debug.dump(Debug.INFO_LOG_LEVEL, ir, label);
     }
 
     boolean verify() {

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScanOptimizeSpillPositionPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScanOptimizeSpillPositionPhase.java
@@ -112,17 +112,17 @@ public final class LinearScanOptimizeSpillPositionPhase extends AllocationPhase 
                 interval.setSpillState(SpillState.StoreAtDefinition);
                 return;
             }
-            Debug.log(3, "Spill block candidate (initial): %s", spillBlock);
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "Spill block candidate (initial): %s", spillBlock);
             // move out of loops
             if (defBlock.getLoopDepth() < spillBlock.getLoopDepth()) {
                 spillBlock = moveSpillOutOfLoop(defBlock, spillBlock);
             }
-            Debug.log(3, "Spill block candidate (after loop optimizaton): %s", spillBlock);
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "Spill block candidate (after loop optimizaton): %s", spillBlock);
 
             /*
              * The spill block is the begin of the first split child (aka the value is on the
              * stack).
-             * 
+             *
              * The problem is that if spill block has more than one predecessor, the values at the
              * end of the predecessors might differ. Therefore, we would need a spill move in all
              * predecessors. To avoid this we spill in the dominator.
@@ -136,7 +136,7 @@ public final class LinearScanOptimizeSpillPositionPhase extends AllocationPhase 
                 spillBlock = dom;
             }
             if (defBlock.equals(spillBlock)) {
-                Debug.log(3, "Definition is the best choice: %s", defBlock);
+                Debug.log(Debug.VERBOSE_LOG_LEVEL, "Definition is the best choice: %s", defBlock);
                 // definition is the best choice
                 interval.setSpillState(SpillState.StoreAtDefinition);
                 return;
@@ -148,7 +148,7 @@ public final class LinearScanOptimizeSpillPositionPhase extends AllocationPhase 
             }
 
             if (defBlock.probability() <= spillBlock.probability()) {
-                Debug.log(3, "Definition has lower probability %s (%f) is lower than spill block %s (%f)", defBlock, defBlock.probability(), spillBlock, spillBlock.probability());
+                Debug.log(Debug.VERBOSE_LOG_LEVEL, "Definition has lower probability %s (%f) is lower than spill block %s (%f)", defBlock, defBlock.probability(), spillBlock, spillBlock.probability());
                 // better spill block has the same probability -> do nothing
                 interval.setSpillState(SpillState.StoreAtDefinition);
                 return;
@@ -165,7 +165,7 @@ public final class LinearScanOptimizeSpillPositionPhase extends AllocationPhase 
             AllocatableValue fromLocation = interval.getSplitChildAtOpId(spillOpId, OperandMode.DEF, allocator).location();
             AllocatableValue toLocation = LinearScan.canonicalSpillOpr(interval);
             LIRInstruction move = allocator.getSpillMoveFactory().createMove(toLocation, fromLocation);
-            Debug.log(3, "Insert spill move %s", move);
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "Insert spill move %s", move);
             move.setId(LinearScan.DOMINATOR_SPILL_MOVE_ID);
             /*
              * We can use the insertion buffer directly because we always insert at position 1.

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScanWalker.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/lsra/LinearScanWalker.java
@@ -855,7 +855,7 @@ class LinearScanWalker extends IntervalWalker {
                          * errors
                          */
                         allocator.assignSpillSlot(interval);
-                        Debug.dump(allocator.getLIR(), description);
+                        Debug.dump(Debug.INFO_LOG_LEVEL, allocator.getLIR(), description);
                         allocator.printIntervals(description);
                         throw new OutOfRegistersException("LinearScan: no register found", description);
                     }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/TraceRegisterAllocationPhase.java
@@ -91,7 +91,7 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
         TraceAllocationContext traceContext = new TraceAllocationContext(spillMoveFactory, registerAllocationConfig, resultTraces);
         AllocatableValue[] cachedStackSlots = Options.TraceRACacheStackSlots.getValue() ? new AllocatableValue[lir.numVariables()] : null;
 
-        Debug.dump(lir, "Before TraceRegisterAllocation");
+        Debug.dump(Debug.INFO_LOG_LEVEL, lir, "Before TraceRegisterAllocation");
         try (Scope s0 = Debug.scope("AllocateTraces", resultTraces)) {
             for (Trace<B> trace : resultTraces.getTraces()) {
                 try (Indent i = Debug.logAndIndent("Allocating Trace%d: %s", trace.getId(), trace); Scope s = Debug.scope("AllocateTrace", trace)) {
@@ -114,7 +114,7 @@ public final class TraceRegisterAllocationPhase extends AllocationPhase {
         } catch (Throwable e) {
             throw Debug.handle(e);
         }
-        Debug.dump(lir, "After trace allocation");
+        Debug.dump(Debug.INFO_LOG_LEVEL, lir, "After trace allocation");
 
         TRACE_GLOBAL_MOVE_RESOLUTION_PHASE.apply(target, lirGenRes, codeEmittingOrder, linearScanOrder, traceContext);
         deconstructSSIForm(lir);

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScan.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScan.java
@@ -825,7 +825,7 @@ public final class TraceLinearScan {
                     }
                 }
             }
-            Debug.dump(new TraceIntervalDumper(Arrays.copyOf(fixedIntervals, fixedIntervals.length), Arrays.copyOf(intervals, intervalsSize)), label);
+            Debug.dump(Debug.INFO_LOG_LEVEL, new TraceIntervalDumper(Arrays.copyOf(fixedIntervals, fixedIntervals.length), Arrays.copyOf(intervals, intervalsSize)), label);
         }
     }
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanWalker.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/alloc/trace/lsra/TraceLinearScanWalker.java
@@ -904,7 +904,7 @@ final class TraceLinearScanWalker extends TraceIntervalWalker {
                              * avoid errors
                              */
                             allocator.assignSpillSlot(interval);
-                            if (Debug.isDumpEnabled()) {
+                            if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
                                 dumpLIRAndIntervals(description);
                             }
                             throw new OutOfRegistersException("LinearScan: no register found", description);
@@ -941,7 +941,7 @@ final class TraceLinearScanWalker extends TraceIntervalWalker {
     }
 
     protected void dumpLIRAndIntervals(String description) {
-        Debug.dump(allocator.getLIR(), description);
+        Debug.dump(Debug.INFO_LOG_LEVEL, allocator.getLIR(), description);
         allocator.printIntervals(description);
     }
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/asm/CompilationResultBuilder.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/asm/CompilationResultBuilder.java
@@ -406,12 +406,12 @@ public class CompilationResultBuilder {
     }
 
     private void emitBlock(AbstractBlockBase<?> block) {
-        if (Debug.isDumpEnabled() || PrintLIRWithAssembly.getValue()) {
+        if (Debug.isDumpEnabled(Debug.BASIC_LOG_LEVEL) || PrintLIRWithAssembly.getValue()) {
             blockComment(String.format("block B%d %s", block.getId(), block.getLoop()));
         }
 
         for (LIRInstruction op : lir.getLIRforBlock(block)) {
-            if (Debug.isDumpEnabled() || PrintLIRWithAssembly.getValue()) {
+            if (Debug.isDumpEnabled(Debug.BASIC_LOG_LEVEL) || PrintLIRWithAssembly.getValue()) {
                 blockComment(String.format("%d %s", op.id(), op));
             }
 

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/constopt/ConstantLoadOptimization.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/constopt/ConstantLoadOptimization.java
@@ -215,7 +215,7 @@ public final class ConstantLoadOptimization extends PreAllocationOptimizationPha
                                     phiConstantsSkipped.increment();
                                 }
                                 phiConstants.set(var.index);
-                                Debug.log(3, "Removing phi variable: %s", var);
+                                Debug.log(Debug.VERBOSE_LOG_LEVEL, "Removing phi variable: %s", var);
                             }
                         } else {
                             assert defined.get(var.index) : "phi but not defined? " + var;
@@ -292,7 +292,7 @@ public final class ConstantLoadOptimization extends PreAllocationOptimizationPha
                 // no better solution found
                 materializeAtDefinitionSkipped.increment();
             }
-            Debug.dump(constTree, "ConstantTree for %s", tree.getVariable());
+            Debug.dump(Debug.INFO_LOG_LEVEL, constTree, "ConstantTree for %s", tree.getVariable());
         }
 
         private void createLoads(DefUseTree tree, ConstantTree constTree, AbstractBlockBase<?> startBlock) {

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/constopt/ConstantTreeAnalyzer.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/constopt/ConstantTreeAnalyzer.java
@@ -73,25 +73,25 @@ public final class ConstantTreeAnalyzer {
         worklist.offerLast(startBlock);
         while (!worklist.isEmpty()) {
             AbstractBlockBase<?> block = worklist.pollLast();
-            try (Indent i = Debug.logAndIndent(3, "analyze: %s", block)) {
+            try (Indent i = Debug.logAndIndent(Debug.VERBOSE_LOG_LEVEL, "analyze: %s", block)) {
                 assert block != null : "worklist is empty!";
                 assert isMarked(block) : "Block not part of the dominator tree: " + block;
 
                 if (isLeafBlock(block)) {
-                    Debug.log(3, "leaf block");
+                    Debug.log(Debug.VERBOSE_LOG_LEVEL, "leaf block");
                     leafCost(block);
                     continue;
                 }
 
                 if (!visited.get(block.getId())) {
                     // if not yet visited (and not a leaf block) process all children first!
-                    Debug.log(3, "not marked");
+                    Debug.log(Debug.VERBOSE_LOG_LEVEL, "not marked");
                     worklist.offerLast(block);
                     List<? extends AbstractBlockBase<?>> children = block.getDominated();
                     children.forEach(child -> filteredPush(worklist, child));
                     visited.set(block.getId());
                 } else {
-                    Debug.log(3, "marked");
+                    Debug.log(Debug.VERBOSE_LOG_LEVEL, "marked");
                     // otherwise, process block
                     process(block);
                 }
@@ -161,7 +161,7 @@ public final class ConstantTreeAnalyzer {
 
     private void filteredPush(Deque<AbstractBlockBase<?>> worklist, AbstractBlockBase<?> block) {
         if (isMarked(block)) {
-            Debug.log(3, "adding %s to the worklist", block);
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "adding %s to the worklist", block);
             worklist.offerLast(block);
         }
     }

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/LIRPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/phases/LIRPhase.java
@@ -52,8 +52,6 @@ public abstract class LIRPhase<C> {
         // @formatter:on
     }
 
-    private static final int PHASE_DUMP_LEVEL = 2;
-
     private CharSequence name;
 
     /**
@@ -123,8 +121,8 @@ public abstract class LIRPhase<C> {
         try (Scope s = Debug.scope(getName(), this)) {
             try (DebugCloseable a = timer.start(); DebugCloseable c = memUseTracker.start()) {
                 run(target, lirGenRes, codeEmittingOrder, linearScanOrder, context);
-                if (dumpLIR && Debug.isDumpEnabled(PHASE_DUMP_LEVEL)) {
-                    Debug.dump(PHASE_DUMP_LEVEL, lirGenRes.getLIR(), "%s", getName());
+                if (dumpLIR && Debug.isDumpEnabled(Debug.BASIC_LOG_LEVEL)) {
+                    Debug.dump(Debug.BASIC_LOG_LEVEL, lirGenRes.getLIR(), "%s", getName());
                 }
             }
         } catch (Throwable e) {

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIConstructionPhase.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/ssi/SSIConstructionPhase.java
@@ -345,7 +345,7 @@ public final class SSIConstructionPhase extends AllocationPhase {
 
         @SuppressWarnings("try")
         private void finish() {
-            Debug.dump(getLIR(), "Before SSI operands");
+            Debug.dump(Debug.INFO_LOG_LEVEL, getLIR(), "Before SSI operands");
             for (AbstractBlockBase<?> block : getBlocks()) {
                 try (Indent indent = Debug.logAndIndent("Finish Block %s", block)) {
                     // set label

--- a/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/stackslotalloc/LSStackSlotAllocator.java
+++ b/graal/com.oracle.graal.lir/src/com/oracle/graal/lir/stackslotalloc/LSStackSlotAllocator.java
@@ -131,7 +131,7 @@ public final class LSStackSlotAllocator extends AllocationPhase {
 
         @SuppressWarnings("try")
         private void allocate() {
-            Debug.dump(lir, "After StackSlot numbering");
+            Debug.dump(Debug.INFO_LOG_LEVEL, lir, "After StackSlot numbering");
 
             long currentFrameSize = StackSlotAllocatorUtil.allocatedFramesize.isEnabled() ? frameMapBuilder.getFrameMap().currentFrameSize() : 0;
             Set<LIRInstruction> usePos;
@@ -145,14 +145,14 @@ public final class LSStackSlotAllocator extends AllocationPhase {
                     assert verifyIntervals();
                 }
             }
-            if (Debug.isDumpEnabled()) {
+            if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
                 dumpIntervals("Before stack slot allocation");
             }
             // step 4: allocate stack slots
             try (DebugCloseable t = AllocateSlotsTimer.start()) {
                 allocateStackSlots();
             }
-            if (Debug.isDumpEnabled()) {
+            if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
                 dumpIntervals("After stack slot allocation");
             }
 
@@ -160,7 +160,7 @@ public final class LSStackSlotAllocator extends AllocationPhase {
             try (DebugCloseable t = AssignSlotsTimer.start()) {
                 assignStackSlots(usePos);
             }
-            Debug.dump(lir, "After StackSlot assignment");
+            Debug.dump(Debug.INFO_LOG_LEVEL, lir, "After StackSlot assignment");
             if (StackSlotAllocatorUtil.allocatedFramesize.isEnabled()) {
                 StackSlotAllocatorUtil.allocatedFramesize.add(frameMapBuilder.getFrameMap().currentFrameSize() - currentFrameSize);
             }
@@ -256,13 +256,13 @@ public final class LSStackSlotAllocator extends AllocationPhase {
                      */
                     location = StackSlot.get(current.kind(), slot.getRawOffset(), slot.getRawAddFrameSize());
                     StackSlotAllocatorUtil.reusedSlots.increment();
-                    Debug.log(1, "Reuse stack slot %s (reallocated from %s) for virtual stack slot %s", location, slot, virtualSlot);
+                    Debug.log(Debug.BASIC_LOG_LEVEL, "Reuse stack slot %s (reallocated from %s) for virtual stack slot %s", location, slot, virtualSlot);
                 } else {
                     // Allocate new stack slot.
                     location = frameMapBuilder.getFrameMap().allocateSpillSlot(virtualSlot.getLIRKind());
                     StackSlotAllocatorUtil.virtualFramesize.add(frameMapBuilder.getFrameMap().spillSlotSize(virtualSlot.getLIRKind()));
                     StackSlotAllocatorUtil.allocatedSlots.increment();
-                    Debug.log(1, "New stack slot %s for virtual stack slot %s", location, virtualSlot);
+                    Debug.log(Debug.BASIC_LOG_LEVEL, "New stack slot %s for virtual stack slot %s", location, virtualSlot);
                 }
             }
             Debug.log("Allocate location %s for interval %s", location, current);
@@ -433,7 +433,7 @@ public final class LSStackSlotAllocator extends AllocationPhase {
         }
 
         private void dumpIntervals(String label) {
-            Debug.dump(new StackIntervalDumper(Arrays.copyOf(stackSlotMap, stackSlotMap.length)), label);
+            Debug.dump(Debug.INFO_LOG_LEVEL, new StackIntervalDumper(Arrays.copyOf(stackSlotMap, stackSlotMap.length)), label);
         }
 
     }

--- a/graal/com.oracle.graal.loop.phases/src/com/oracle/graal/loop/phases/LoopFullUnrollPhase.java
+++ b/graal/com.oracle.graal.loop.phases/src/com/oracle/graal/loop/phases/LoopFullUnrollPhase.java
@@ -54,7 +54,7 @@ public class LoopFullUnrollPhase extends LoopPhase<LoopPolicies> {
                         Debug.log("FullUnroll %s", loop);
                         LoopTransformations.fullUnroll(loop, context, canonicalizer);
                         FULLY_UNROLLED_LOOPS.increment();
-                        Debug.dump(graph, "FullUnroll %s", loop);
+                        Debug.dump(Debug.INFO_LOG_LEVEL, graph, "FullUnroll %s", loop);
                         peeled = true;
                         break;
                     }

--- a/graal/com.oracle.graal.loop.phases/src/com/oracle/graal/loop/phases/LoopPeelingPhase.java
+++ b/graal/com.oracle.graal.loop.phases/src/com/oracle/graal/loop/phases/LoopPeelingPhase.java
@@ -42,7 +42,7 @@ public class LoopPeelingPhase extends ContextlessLoopPhase<LoopPolicies> {
                 if (getPolicies().shouldPeel(loop, data.getCFG())) {
                     Debug.log("Peeling %s", loop);
                     LoopTransformations.peel(loop);
-                    Debug.dump(graph, "Peeling %s", loop);
+                    Debug.dump(Debug.INFO_LOG_LEVEL, graph, "Peeling %s", loop);
                 }
             }
             data.deleteUnusedNodes();

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/GraphDecoder.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/GraphDecoder.java
@@ -1160,13 +1160,13 @@ public class GraphDecoder {
     }
 
     protected void detectLoops(MethodScope methodScope, FixedNode startInstruction) {
-        Debug.dump(1, methodScope.graph, "Before detectLoops");
+        Debug.dump(Debug.VERBOSE_LOG_LEVEL, methodScope.graph, "Before detectLoops");
         Set<LoopBeginNode> newLoopBegins = insertLoopBegins(methodScope, startInstruction);
 
-        Debug.dump(1, methodScope.graph, "Before insertLoopExits");
+        Debug.dump(Debug.VERBOSE_LOG_LEVEL, methodScope.graph, "Before insertLoopExits");
 
         insertLoopExits(methodScope, startInstruction, newLoopBegins);
-        Debug.dump(1, methodScope.graph, "After detectLoops");
+        Debug.dump(Debug.VERBOSE_LOG_LEVEL, methodScope.graph, "After detectLoops");
     }
 
     private static Set<LoopBeginNode> insertLoopBegins(MethodScope methodScope, FixedNode startInstruction) {
@@ -1327,7 +1327,7 @@ public class GraphDecoder {
                  * loop iteration. This is mostly the state that we want, we only need to tweak it a
                  * little bit: we need to insert the appropriate ProxyNodes for all values that are
                  * created inside the loop and that flow out of the loop.
-                 * 
+                 *
                  * In some cases, we did not create a FrameState during graph decoding: when there
                  * was no LoopExit in the original loop that we exploded. This happens for code
                  * paths that lead immediately to a DeoptimizeNode. Since the BytecodeParser does

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/GraphEncoder.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/GraphEncoder.java
@@ -411,8 +411,8 @@ public class GraphEncoder {
             GraphComparison.verifyGraphsEqual(originalGraph, decodedGraph);
         } catch (Throwable ex) {
             try (Debug.Scope scope = Debug.scope("GraphEncoder")) {
-                Debug.dump(originalGraph, "Original Graph");
-                Debug.dump(decodedGraph, "Decoded Graph");
+                Debug.dump(Debug.INFO_LOG_LEVEL, originalGraph, "Original Graph");
+                Debug.dump(Debug.INFO_LOG_LEVEL, decodedGraph, "Decoded Graph");
             }
             throw ex;
         }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/cfg/ControlFlowGraph.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/cfg/ControlFlowGraph.java
@@ -383,7 +383,7 @@ public final class ControlFlowGraph implements AbstractControlFlowGraph<Block> {
                                 if (sux.loop != loop) {
                                     AbstractBeginNode begin = sux.getBeginNode();
                                     if (!(begin instanceof LoopExitNode && ((LoopExitNode) begin).loopBegin() == loopBegin)) {
-                                        Debug.log(3, "Unexpected loop exit with %s, including whole branch in the loop", sux);
+                                        Debug.log(Debug.VERBOSE_LOG_LEVEL, "Unexpected loop exit with %s, including whole branch in the loop", sux);
                                         computeLoopBlocks(sux, loop, stack, false);
                                     }
                                 }

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/CanonicalizerPhase.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/CanonicalizerPhase.java
@@ -295,7 +295,7 @@ public class CanonicalizerPhase extends BasePhase<PhaseContext> {
             }
 
             if (nodeClass.isSimplifiable() && simplify) {
-                Debug.log(3, "Canonicalizer: simplifying %s", node);
+                Debug.log(Debug.VERBOSE_LOG_LEVEL, "Canonicalizer: simplifying %s", node);
                 METRIC_SIMPLIFICATION_CONSIDERED_NODES.increment();
                 node.simplify(tool);
                 return node.isDeleted();
@@ -321,7 +321,7 @@ public class CanonicalizerPhase extends BasePhase<PhaseContext> {
 // @formatter:on
         private boolean performReplacement(final Node node, Node newCanonical) {
             if (newCanonical == node) {
-                Debug.log(3, "Canonicalizer: work on %1s", node);
+                Debug.log(Debug.VERBOSE_LOG_LEVEL, "Canonicalizer: work on %1s", node);
                 return false;
             } else {
                 Node canonical = newCanonical;

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/DominatorConditionalEliminationPhase.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/DominatorConditionalEliminationPhase.java
@@ -848,7 +848,7 @@ public class DominatorConditionalEliminationPhase extends Phase {
         }
 
         public void pushElement(InfoElement element) {
-            Debug.log(4, "Pushing an info element:%s   size %d", element, infos);
+            Debug.log(Debug.VERBOSE_LOG_LEVEL, "Pushing an info element:%s   size %d", element, infos);
             infos.add(element);
         }
 

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/inlining/walker/InliningData.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/inlining/walker/InliningData.java
@@ -386,7 +386,7 @@ public class InliningData {
                 Collection<Node> parameterUsages = calleeInfo.inline(new Providers(context));
                 canonicalizedNodes.addAll(parameterUsages);
                 metricInliningRuns.increment();
-                Debug.dump(callerGraph, "after %s", calleeInfo);
+                Debug.dump(Debug.INFO_LOG_LEVEL, callerGraph, "after %s", calleeInfo);
 
                 if (OptCanonicalizer.getValue()) {
                     Graph.Mark markBeforeCanonicalization = callerGraph.getMark();
@@ -560,7 +560,7 @@ public class InliningData {
      * Gets the call hierarchy of this inlining from outer most call to inner most callee.
      */
     private Object[] inliningContext() {
-        if (!Debug.isDumpEnabled()) {
+        if (!Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
             return NO_CONTEXT;
         }
         Object[] result = new Object[graphQueue.size()];

--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/instrumentation/ExtractInstrumentationPhase.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/instrumentation/ExtractInstrumentationPhase.java
@@ -68,7 +68,7 @@ public class ExtractInstrumentationPhase extends BasePhase<HighTierContext> {
             if (!instrumentation.inspectingIntrinsic()) {
                 InstrumentationNode instrumentationNode = instrumentation.createInstrumentationNode();
                 graph.addBeforeFixed(begin, instrumentationNode);
-                Debug.dump(instrumentationNode.instrumentationGraph(), "After extracted instrumentation at %s", instrumentation);
+                Debug.dump(Debug.INFO_LOG_LEVEL, instrumentationNode.instrumentationGraph(), "After extracted instrumentation at %s", instrumentation);
             }
             instrumentation.unlink();
         }

--- a/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/BasePhase.java
+++ b/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/BasePhase.java
@@ -41,9 +41,6 @@ import com.oracle.graal.nodes.StructuredGraph;
  */
 public abstract class BasePhase<C> {
 
-    public static final int PHASE_DUMP_LEVEL = 1;
-    public static final int BEFORE_PHASE_DUMP_LEVEL = 3;
-
     private CharSequence name;
 
     /**
@@ -139,14 +136,14 @@ public abstract class BasePhase<C> {
     @SuppressWarnings("try")
     protected final void apply(final StructuredGraph graph, final C context, final boolean dumpGraph) {
         try (DebugCloseable a = timer.start(); Scope s = Debug.scope(getClass(), this); DebugCloseable c = memUseTracker.start()) {
-            if (dumpGraph && Debug.isDumpEnabled(BEFORE_PHASE_DUMP_LEVEL)) {
-                Debug.dump(BEFORE_PHASE_DUMP_LEVEL, graph, "Before phase %s", getName());
+            if (dumpGraph && Debug.isDumpEnabled(Debug.VERBOSE_LOG_LEVEL)) {
+                Debug.dump(Debug.VERBOSE_LOG_LEVEL, graph, "Before phase %s", getName());
             }
             inputNodesCount.add(graph.getNodeCount());
             this.run(graph, context);
             executionCount.increment();
-            if (dumpGraph && Debug.isDumpEnabled(PHASE_DUMP_LEVEL)) {
-                Debug.dump(PHASE_DUMP_LEVEL, graph, "%s", getName());
+            if (dumpGraph && Debug.isDumpEnabled(Debug.BASIC_LOG_LEVEL)) {
+                Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "%s", getName());
             }
             if (Fingerprint.ENABLED) {
                 String graphDesc = graph.method() == null ? graph.name : graph.method().format("%H.%n(%p)");

--- a/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/verify/VerifyDebugUsage.java
+++ b/graal/com.oracle.graal.phases/src/com/oracle/graal/phases/verify/VerifyDebugUsage.java
@@ -42,10 +42,10 @@ import jdk.vm.ci.meta.ResolvedJavaType;
  * Additionally this phase verifies that no argument is the result of a call to
  * {@link StringBuilder#toString()} or {@link StringBuffer#toString()}. Ideally the parameters at
  * callsites of {@link Debug} are eliminated, and do not produce additional allocations, if
- * {@link Debug#isDumpEnabled()} (or {@link Debug#isLogEnabled()}, ...) is {@code false}.
+ * {@link Debug#isDumpEnabled(int)} (or {@link Debug#isLogEnabled(int)}, ...) is {@code false}.
  *
  * Methods in {@link Debug} checked by this phase are various different versions of
- * {@link Debug#log(String)} , {@link Debug#dump(Object, String)},
+ * {@link Debug#log(String)} , {@link Debug#dump(int, Object, String)},
  * {@link Debug#logAndIndent(String)} and {@link Debug#verify(Object, String)}.
  */
 public class VerifyDebugUsage extends VerifyPhase<PhaseContext> {

--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/InstanceOfTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/InstanceOfTest.java
@@ -488,7 +488,7 @@ public class InstanceOfTest extends TypeCheckTest {
         try (Scope s = Debug.scope("InstanceOfTest", getMetaAccess().lookupJavaMethod(getMethod(snippet)))) {
             StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
             compile(graph.method(), graph);
-            Debug.dump(graph, snippet);
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, snippet);
             return graph;
         } catch (Throwable e) {
             throw Debug.handle(e);

--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/MethodSubstitutionTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/MethodSubstitutionTest.java
@@ -53,9 +53,9 @@ public abstract class MethodSubstitutionTest extends GraalCompilerTest {
         try (Scope s = Debug.scope("MethodSubstitutionTest", getResolvedJavaMethod(snippet))) {
             StructuredGraph graph = parseEager(snippet, AllowAssumptions.YES);
             HighTierContext context = getDefaultHighTierContext();
-            Debug.dump(graph, "Graph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
             new InliningPhase(new CanonicalizerPhase()).apply(graph, context);
-            Debug.dump(graph, "Graph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "Graph");
             new CanonicalizerPhase().apply(graph, context);
             new DeadCodeEliminationPhase().apply(graph);
 

--- a/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/PEGraphDecoderTest.java
+++ b/graal/com.oracle.graal.replacements.test/src/com/oracle/graal/replacements/test/PEGraphDecoderTest.java
@@ -136,7 +136,7 @@ public class PEGraphDecoderTest extends GraalCompilerTest {
 
             targetGraph = new StructuredGraph(testMethod, AllowAssumptions.YES);
             decoder.decode(targetGraph, testMethod, null, null, new InlineInvokePlugin[]{new InlineAll()}, null);
-            Debug.dump(targetGraph, "Target Graph");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, targetGraph, "Target Graph");
             targetGraph.verify();
 
             PhaseContext context = new PhaseContext(getProviders());
@@ -145,7 +145,7 @@ public class PEGraphDecoderTest extends GraalCompilerTest {
 
         } catch (Throwable ex) {
             if (targetGraph != null) {
-                Debug.dump(targetGraph, ex.toString());
+                Debug.dump(Debug.BASIC_LOG_LEVEL, targetGraph, ex.toString());
             }
             Debug.handle(ex);
         }

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/PEGraphDecoder.java
@@ -579,8 +579,8 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
             plugin.notifyAfterInline(inlineMethod);
         }
 
-        if (Debug.isDumpEnabled() && DumpDuringGraphBuilding.getValue()) {
-            Debug.dump(methodScope.graph, "Inline finished: %s.%s", inlineMethod.getDeclaringClass().getUnqualifiedName(), inlineMethod.getName());
+        if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL) && DumpDuringGraphBuilding.getValue()) {
+            Debug.dump(Debug.INFO_LOG_LEVEL, methodScope.graph, "Inline finished: %s.%s", inlineMethod.getDeclaringClass().getUnqualifiedName(), inlineMethod.getName());
         }
         return true;
     }

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/ReplacementsImpl.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/ReplacementsImpl.java
@@ -304,7 +304,7 @@ public class ReplacementsImpl implements Replacements, InlineInvokePlugin {
 
                 finalizeGraph(graph);
 
-                Debug.dump(graph, "%s: Final", method.getName());
+                Debug.dump(Debug.INFO_LOG_LEVEL, graph, "%s: Final", method.getName());
 
                 return graph;
             } catch (Throwable e) {

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/SnippetTemplate.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/SnippetTemplate.java
@@ -711,7 +711,7 @@ public class SnippetTemplate {
             }
             snippetCopy.addDuplicates(snippetGraph.getNodes(), snippetGraph, snippetGraph.getNodeCount(), nodeReplacements);
 
-            Debug.dump(snippetCopy, "Before specialization");
+            Debug.dump(Debug.INFO_LOG_LEVEL, snippetCopy, "Before specialization");
 
             // Gather the template parameters
             parameters = new Object[parameterCount];
@@ -739,10 +739,10 @@ public class SnippetTemplate {
                     for (Node usage : placeholder.usages().snapshot()) {
                         if (usage instanceof LoadIndexedNode) {
                             LoadIndexedNode loadIndexed = (LoadIndexedNode) usage;
-                            Debug.dump(snippetCopy, "Before replacing %s", loadIndexed);
+                            Debug.dump(Debug.INFO_LOG_LEVEL, snippetCopy, "Before replacing %s", loadIndexed);
                             LoadSnippetVarargParameterNode loadSnippetParameter = snippetCopy.add(new LoadSnippetVarargParameterNode(params, loadIndexed.index(), loadIndexed.stamp()));
                             snippetCopy.replaceFixedWithFixed(loadIndexed, loadSnippetParameter);
-                            Debug.dump(snippetCopy, "After replacing %s", loadIndexed);
+                            Debug.dump(Debug.INFO_LOG_LEVEL, snippetCopy, "After replacing %s", loadIndexed);
                         } else if (usage instanceof StoreIndexedNode) {
                             /*
                              * The template lowering doesn't really treat this as an array so you
@@ -831,7 +831,7 @@ public class SnippetTemplate {
 
             this.snippet = snippetCopy;
 
-            Debug.dump(snippet, "SnippetTemplate after fixing memory anchoring");
+            Debug.dump(Debug.INFO_LOG_LEVEL, snippet, "SnippetTemplate after fixing memory anchoring");
 
             StartNode entryPointNode = snippet.start();
             if (anchor.hasNoUsages()) {
@@ -875,7 +875,7 @@ public class SnippetTemplate {
             }
 
             Debug.metric("SnippetTemplateNodeCount[%#s]", args).add(nodes.size());
-            Debug.dump(snippet, "SnippetTemplate final state");
+            Debug.dump(Debug.INFO_LOG_LEVEL, snippet, "SnippetTemplate final state");
 
         } catch (Throwable ex) {
             throw Debug.handle(ex);
@@ -1284,7 +1284,7 @@ public class SnippetTemplate {
             Map<Node, Node> replacements = bind(replaceeGraph, metaAccess, args);
             replacements.put(entryPointNode, AbstractBeginNode.prevBegin(replacee));
             Map<Node, Node> duplicates = replaceeGraph.addDuplicates(nodes, snippet, snippet.getNodeCount(), replacements);
-            Debug.dump(replaceeGraph, "After inlining snippet %s", snippet.method());
+            Debug.dump(Debug.INFO_LOG_LEVEL, replaceeGraph, "After inlining snippet %s", snippet.method());
 
             // Re-wire the control flow graph around the replacee
             FixedNode firstCFGNodeDuplicate = (FixedNode) duplicates.get(firstCFGNode);
@@ -1390,7 +1390,7 @@ public class SnippetTemplate {
             // Remove the replacee from its graph
             GraphUtil.killCFG(replacee);
 
-            Debug.dump(replaceeGraph, "After lowering %s with %s", replacee, this);
+            Debug.dump(Debug.INFO_LOG_LEVEL, replaceeGraph, "After lowering %s with %s", replacee, this);
             return duplicates;
         }
     }
@@ -1450,7 +1450,7 @@ public class SnippetTemplate {
             Map<Node, Node> replacements = bind(replaceeGraph, metaAccess, args);
             replacements.put(entryPointNode, tool.getCurrentGuardAnchor().asNode());
             Map<Node, Node> duplicates = replaceeGraph.addDuplicates(nodes, snippet, snippet.getNodeCount(), replacements);
-            Debug.dump(replaceeGraph, "After inlining snippet %s", snippetCopy.method());
+            Debug.dump(Debug.INFO_LOG_LEVEL, replaceeGraph, "After inlining snippet %s", snippetCopy.method());
 
             FixedWithNextNode lastFixedNode = tool.lastFixedNode();
             assert lastFixedNode != null && lastFixedNode.isAlive() : replaceeGraph + " lastFixed=" + lastFixedNode;
@@ -1480,7 +1480,7 @@ public class SnippetTemplate {
                 returnDuplicate.replaceAndDelete(next);
             }
 
-            Debug.dump(replaceeGraph, "After lowering %s with %s", replacee, this);
+            Debug.dump(Debug.INFO_LOG_LEVEL, replaceeGraph, "After lowering %s with %s", replacee, this);
         }
     }
 

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/nodes/MacroNode.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/nodes/MacroNode.java
@@ -153,7 +153,7 @@ public abstract class MacroNode extends FixedWithNextNode implements Lowerable {
                 }
             }
             InliningUtil.inline(invoke, replacementGraph, false, null);
-            Debug.dump(graph(), "After inlining replacement %s", replacementGraph);
+            Debug.dump(Debug.INFO_LOG_LEVEL, graph(), "After inlining replacement %s", replacementGraph);
         } else {
             if (isPlaceholderBci(invoke.bci())) {
                 throw new JVMCIError("%s: cannot lower to invoke with placeholder BCI: %s", graph(), this);

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/PartialEvaluator.java
@@ -151,7 +151,7 @@ public class PartialEvaluator {
     @SuppressWarnings("try")
     public StructuredGraph createGraph(final OptimizedCallTarget callTarget, AllowAssumptions allowAssumptions) {
         try (Scope c = Debug.scope("TruffleTree")) {
-            Debug.dump(callTarget, "%s", callTarget);
+            Debug.dump(Debug.INFO_LOG_LEVEL, callTarget, "%s", callTarget);
         } catch (Throwable e) {
             throw Debug.handle(e);
         }
@@ -403,7 +403,7 @@ public class PartialEvaluator {
     @SuppressWarnings({"try", "unused"})
     private void fastPartialEvaluation(OptimizedCallTarget callTarget, StructuredGraph graph, PhaseContext baseContext, HighTierContext tierContext) {
         doGraphPE(callTarget, graph, tierContext);
-        Debug.dump(graph, "After FastPE");
+        Debug.dump(Debug.INFO_LOG_LEVEL, graph, "After FastPE");
 
         graph.maybeCompress();
 
@@ -483,7 +483,7 @@ public class PartialEvaluator {
 
         if (Debug.isEnabled() && !warnings.isEmpty()) {
             try (Scope s = Debug.scope("TrufflePerformanceWarnings", graph)) {
-                Debug.dump(graph, "performance warnings %s", warnings);
+                Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "performance warnings %s", warnings);
             } catch (Throwable t) {
                 Debug.handle(t);
             }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/TruffleCompiler.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/TruffleCompiler.java
@@ -164,7 +164,7 @@ public abstract class TruffleCompiler {
     @SuppressWarnings("try")
     public CompilationResult compileMethodHelper(StructuredGraph graph, String name, PhaseSuite<HighTierContext> graphBuilderSuite, InstalledCode predefinedInstalledCode) {
         try (Scope s = Debug.scope("TruffleFinal")) {
-            Debug.dump(1, graph, "After TruffleTier");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "After TruffleTier");
         } catch (Throwable e) {
             throw Debug.handle(e);
         }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/substitutions/TruffleGraphBuilderPlugins.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/substitutions/TruffleGraphBuilderPlugins.java
@@ -230,7 +230,7 @@ public class TruffleGraphBuilderPlugins {
                      * and constant folding could still eliminate the call to bailout(). However, we
                      * also want to stop parsing, since we are sure that we will never need the
                      * graph beyond the bailout point.
-                     *
+                     * 
                      * Therefore, we manually emit the call to bailout, which will be intrinsified
                      * later when intrinsifications can no longer be delayed. The call is followed
                      * by a NeverPartOfCompilationNode, which is a control sink and therefore stops
@@ -317,7 +317,7 @@ public class TruffleGraphBuilderPlugins {
                         }
                         sb.append(")");
                     }
-                    Debug.dump(value.graph(), "Graph before bailout at node %s", sb);
+                    Debug.dump(Debug.BASIC_LOG_LEVEL, value.graph(), "Graph before bailout at node %s", sb);
                     throw b.bailout("Partial evaluation did not reduce value to a constant, is a regular compiler node: " + sb);
                 }
             }

--- a/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/EffectsClosure.java
+++ b/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/EffectsClosure.java
@@ -140,7 +140,7 @@ public abstract class EffectsClosure<BlockT extends EffectsBlockState<BlockT>> e
             Debug.log(" ==== cfg kill effects");
             effects.apply(graph, obsoleteNodes, true);
         }
-        Debug.dump(4, graph, "After applying effects");
+        Debug.dump(Debug.VERBOSE_LOG_LEVEL, graph, "After applying effects");
         assert VirtualUtil.assertNonReachable(graph, obsoleteNodes);
         for (Node node : obsoleteNodes) {
             if (node.isAlive()) {

--- a/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/EffectsPhase.java
+++ b/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/EffectsPhase.java
@@ -100,8 +100,8 @@ public abstract class EffectsPhase<PhaseContextT extends PhaseContext> extends B
                         closure.applyEffects();
                     }
 
-                    if (Debug.isDumpEnabled()) {
-                        Debug.dump(graph, "%s iteration", getName());
+                    if (Debug.isDumpEnabled(Debug.INFO_LOG_LEVEL)) {
+                        Debug.dump(Debug.INFO_LOG_LEVEL, graph, "%s iteration", getName());
                     }
 
                     new DeadCodeEliminationPhase(Required).apply(graph);

--- a/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/VirtualUtil.java
+++ b/graal/com.oracle.graal.virtual/src/com/oracle/graal/virtual/phases/ea/VirtualUtil.java
@@ -111,7 +111,7 @@ public final class VirtualUtil {
         }
         if (!success) {
             TTY.println();
-            Debug.dump(graph, "assertNonReachable");
+            Debug.dump(Debug.BASIC_LOG_LEVEL, graph, "assertNonReachable");
         }
         return success;
     }


### PR DESCRIPTION
I made the levels more explicit and forced the call sites to actively pick one.  Most of the ones using dump stayed at level 2 but I tried to change all debugging and testing ones to 1.  I also added support for symbolic names in the dump specifiers so you can say -G:Dump=:verbose to get level 3.  I also adjusted places where a constant integer was being passed instead of a symbolic name.

cc @dougxc @gilles-duboscq @zapster @thomaswue 