### PR TITLE
Cleanup of DefaultTruffleSplittingStrategy

### DIFF
--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
@@ -52,7 +52,7 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
     }
 
     private boolean shouldSplit() {
-        if (call.getClonedCallTarget() != null) {
+        if (call.isCallTargetCloned()) {
             return false;
         }
         if (!TruffleCompilerOptions.TruffleSplitting.getValue()) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
@@ -45,13 +45,13 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
     }
 
     public void forceSplitting() {
-        if (call.isCallTargetCloned()) {
+        if (!canSplit()) {
             return;
         }
         call.installSplitCallTarget(call.getCallTarget().cloneUninitialized());
     }
 
-    private boolean shouldSplit() {
+    private boolean canSplit() {
         if (call.isCallTargetCloned()) {
             return false;
         }
@@ -61,6 +61,14 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
         if (!call.isCallTargetCloningAllowed()) {
             return false;
         }
+        return true;
+    }
+
+    private boolean shouldSplit() {
+        if (!canSplit()) {
+            return false;
+        }
+
         OptimizedCallTarget splitTarget = call.getCallTarget();
         int nodeCount = splitTarget.getNonTrivialNodeCount();
         if (nodeCount > TruffleCompilerOptions.TruffleSplittingMaxCalleeSize.getValue()) {

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
@@ -36,6 +36,7 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
         this.call = call;
     }
 
+    @Override
     public void beforeCall(Object[] arguments) {
         if (call.getCallCount() == 2) {
             if (shouldSplit()) {
@@ -44,6 +45,7 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
         }
     }
 
+    @Override
     public void forceSplitting() {
         if (!canSplit()) {
             return;

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
@@ -71,15 +71,15 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
             return false;
         }
 
-        OptimizedCallTarget splitTarget = call.getCallTarget();
-        int nodeCount = splitTarget.getNonTrivialNodeCount();
+        OptimizedCallTarget callTarget = call.getCallTarget();
+        int nodeCount = callTarget.getNonTrivialNodeCount();
         if (nodeCount > TruffleCompilerOptions.TruffleSplittingMaxCalleeSize.getValue()) {
             return false;
         }
 
         // disable recursive splitting for now
         OptimizedCallTarget root = (OptimizedCallTarget) call.getRootNode().getCallTarget();
-        if (root == splitTarget || root.getSourceCallTarget() == splitTarget) {
+        if (root == callTarget || root.getSourceCallTarget() == callTarget) {
             // recursive call found
             return false;
         }

--- a/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
+++ b/graal/com.oracle.graal.truffle/src/com/oracle/graal/truffle/DefaultTruffleSplittingStrategy.java
@@ -82,7 +82,7 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
     }
 
     private static boolean isMaxSingleCall(OptimizedDirectCallNode call) {
-        return NodeUtil.countNodes(call.getCurrentCallTarget().getRootNode(), new NodeCountFilter() {
+        return NodeUtil.countNodes(call.getCallTarget().getRootNode(), new NodeCountFilter() {
             public boolean isCounted(Node node) {
                 return node instanceof DirectCallNode;
             }
@@ -90,7 +90,7 @@ public final class DefaultTruffleSplittingStrategy implements TruffleSplittingSt
     }
 
     private static int countPolymorphic(OptimizedDirectCallNode call) {
-        return NodeUtil.countNodes(call.getCurrentCallTarget().getRootNode(), new NodeCountFilter() {
+        return NodeUtil.countNodes(call.getCallTarget().getRootNode(), new NodeCountFilter() {
             public boolean isCounted(Node node) {
                 NodeCost cost = node.getCost();
                 boolean polymorphic = cost == NodeCost.POLYMORPHIC || cost == NodeCost.MEGAMORPHIC;


### PR DESCRIPTION
This PR performs various small clean-ups in DefaultTruffleSplittingStrategy.
Additionally, it fixes a case where `forceSplitting()` would split when called directly, even if that is disallowed in Truffle options or by the RootNode.