### PR TITLE
Introduce `DynamicPiNode` to capture improved stamp when a dynamic ca…

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/meta/HotSpotGraphBuilderPlugins.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/meta/HotSpotGraphBuilderPlugins.java
@@ -48,7 +48,6 @@ import sun.reflect.Reflection;
 
 import com.oracle.graal.api.replacements.SnippetReflectionProvider;
 import com.oracle.graal.compiler.common.spi.ForeignCallsProvider;
-import com.oracle.graal.compiler.common.type.StampFactory;
 import com.oracle.graal.hotspot.nodes.CurrentJavaThreadNode;
 import com.oracle.graal.hotspot.replacements.AESCryptSubstitutions;
 import com.oracle.graal.hotspot.replacements.CRC32Substitutions;
@@ -66,6 +65,7 @@ import com.oracle.graal.hotspot.replacements.ThreadSubstitutions;
 import com.oracle.graal.hotspot.replacements.arraycopy.ArrayCopyNode;
 import com.oracle.graal.hotspot.word.HotSpotWordTypes;
 import com.oracle.graal.nodes.ConstantNode;
+import com.oracle.graal.nodes.DynamicPiNode;
 import com.oracle.graal.nodes.FixedGuardNode;
 import com.oracle.graal.nodes.LogicNode;
 import com.oracle.graal.nodes.NamedLocationIdentity;
@@ -188,7 +188,7 @@ public class HotSpotGraphBuilderPlugins {
                     b.addPush(JavaKind.Object, object);
                 } else {
                     FixedGuardNode fixedGuard = b.add(new FixedGuardNode(condition, DeoptimizationReason.ClassCastException, DeoptimizationAction.InvalidateReprofile, false));
-                    b.addPush(JavaKind.Object, new PiNode(object, StampFactory.object(), fixedGuard));
+                    b.addPush(JavaKind.Object, new DynamicPiNode(object, fixedGuard, javaClass));
                 }
                 return true;
             }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/DynamicPiNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/DynamicPiNode.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.nodes;
+
+import com.oracle.graal.compiler.common.type.Stamp;
+import com.oracle.graal.compiler.common.type.StampFactory;
+import com.oracle.graal.compiler.common.type.TypeReference;
+import com.oracle.graal.graph.Node;
+import com.oracle.graal.graph.NodeClass;
+import com.oracle.graal.graph.spi.CanonicalizerTool;
+import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.extended.GuardingNode;
+
+import jdk.vm.ci.meta.ResolvedJavaType;
+
+/**
+ * A {@link PiNode} where the type is not yet known. If the type becomes known at a later point in
+ * the compilation, this can canonicalize to a regular {@link PiNode}.
+ */
+@NodeInfo
+public final class DynamicPiNode extends PiNode {
+
+    public static final NodeClass<DynamicPiNode> TYPE = NodeClass.create(DynamicPiNode.class);
+    @Input ValueNode typeMirror;
+
+    public DynamicPiNode(ValueNode object, GuardingNode guard, ValueNode typeMirror) {
+        super(TYPE, object, StampFactory.object(), guard);
+        this.typeMirror = typeMirror;
+    }
+
+    @Override
+    public Node canonical(CanonicalizerTool tool) {
+        if (typeMirror.isConstant()) {
+            ResolvedJavaType t = tool.getConstantReflection().asJavaType(typeMirror.asConstant());
+            if (t != null) {
+                Stamp staticPiStamp;
+                if (t.isPrimitive()) {
+                    staticPiStamp = StampFactory.alwaysNull();
+                } else {
+                    TypeReference type = TypeReference.createTrusted(tool.getAssumptions(), t);
+                    staticPiStamp = StampFactory.object(type);
+                }
+
+                return new PiNode(object(), staticPiStamp, (ValueNode) getGuard());
+            }
+        }
+
+        return this;
+    }
+}

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/PiArrayNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/PiArrayNode.java
@@ -47,7 +47,7 @@ public final class PiArrayNode extends PiNode implements ArrayLengthProvider {
     }
 
     public PiArrayNode(ValueNode object, ValueNode length, Stamp stamp) {
-        super(TYPE, object, stamp);
+        super(TYPE, object, stamp, null);
         this.length = length;
     }
 

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/PiNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/PiNode.java
@@ -67,8 +67,8 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
         return object;
     }
 
-    protected PiNode(NodeClass<? extends PiNode> c, ValueNode object, Stamp stamp) {
-        super(c, stamp, null);
+    protected PiNode(NodeClass<? extends PiNode> c, ValueNode object, Stamp stamp, GuardingNode guard) {
+        super(c, stamp, guard);
         this.object = object;
         this.piStamp = stamp;
     }


### PR DESCRIPTION
…st becomes static later in the compilation.

In contrast to the normal `PiNode`, the `DynamicPiNode` will stick around, even though it doesn't actually improve the stamp. Otherwise we lose the opportunity to improve the stamp later when the input becomes constant.