### PR TITLE
Accessible arguments in ForeignCallNode and values of VirtualObjectNo…

### DIFF
--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/extended/ForeignCallNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/extended/ForeignCallNode.java
@@ -207,4 +207,8 @@ public class ForeignCallNode extends AbstractMemoryCheckpoint implements LIRLowe
     public boolean isGuaranteedSafepoint() {
         return foreignCalls.isGuaranteedSafepoint(descriptor);
     }
+
+    public NodeInputList<ValueNode> getArguments() {
+        return arguments;
+    }
 }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/virtual/CommitAllocationNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/virtual/CommitAllocationNode.java
@@ -217,6 +217,13 @@ public final class CommitAllocationNode extends FixedWithNextNode implements Vir
         }
     }
 
+    /**
+     * For all the virtual object nodes that depends on commit allocation, this method maps the node
+     * with its values. For example, a commit allocation could depend on a {@link VirtualArrayNode}
+     * with many {@link ValueNode}. The hash table will contain the corresponding
+     * {@link VirtualArrayNode} as a key with the array of {@link ValueNode}. This array can be used
+     * to inspect those {@link ValueNode}.
+     */
     public HashMap<VirtualObjectNode, Object[]> getVirtualObjectsArrays() {
         HashMap<VirtualObjectNode, Object[]> arrayValues = new HashMap<>();
         int pos = 0;

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/virtual/CommitAllocationNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/virtual/CommitAllocationNode.java
@@ -220,9 +220,8 @@ public final class CommitAllocationNode extends FixedWithNextNode implements Vir
     /**
      * For all the virtual object nodes that depends on commit allocation, this method maps the node
      * with its values. For example, a commit allocation could depend on a {@link VirtualArrayNode}
-     * with many {@link ValueNode}. The hash table will contain the corresponding
-     * {@link VirtualArrayNode} as a key with the array of {@link ValueNode}. This array can be used
-     * to inspect those {@link ValueNode}.
+     * with many {@link ValueNode}s. The map will contain the corresponding {@link VirtualArrayNode}
+     * as a key with the array of {@link ValueNode}s.
      */
     public HashMap<VirtualObjectNode, Object[]> getVirtualObjectsArrays() {
         HashMap<VirtualObjectNode, Object[]> arrayValues = new HashMap<>();

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/virtual/CommitAllocationNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/virtual/CommitAllocationNode.java
@@ -24,6 +24,7 @@ package com.oracle.graal.nodes.virtual;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -214,6 +215,19 @@ public final class CommitAllocationNode extends FixedWithNextNode implements Vir
             lockIndexes = newLockIndexes;
             ensureVirtual = newEnsureVirtual;
         }
+    }
+
+    public HashMap<VirtualObjectNode, Object[]> getVirtualObjectsArrays() {
+        HashMap<VirtualObjectNode, Object[]> arrayValues = new HashMap<>();
+        int pos = 0;
+        for (int i = 0; i < virtualObjects.size(); i++) {
+            VirtualObjectNode virtualObject = virtualObjects.get(i);
+            int entryCount = virtualObject.entryCount();
+            ValueNode[] array = values.subList(pos, pos + entryCount).toArray(new ValueNode[entryCount]);
+            arrayValues.put(virtualObject, array);
+            pos += entryCount;
+        }
+        return arrayValues;
     }
 
 }


### PR DESCRIPTION
Accessible arguments in ForeignCallNode and values of VirtualObjectNode in CommitAllocationNode.

For the OpenCL code generation from the Graal-IR I have to access to some public fields from ForeignCallNode and CommitAllocationNode. I wonder if they could be public in the future releases.  