### PR TITLE
minor code change to the pow intrinsic to correct a corner case

### DIFF
--- a/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotLoweringProvider.java
+++ b/graal/com.oracle.graal.hotspot.amd64/src/com/oracle/graal/hotspot/amd64/AMD64HotSpotLoweringProvider.java
@@ -28,6 +28,7 @@ import static com.oracle.graal.hotspot.amd64.AMD64HotSpotForeignCallsProvider.AR
 import static com.oracle.graal.hotspot.amd64.AMD64HotSpotForeignCallsProvider.ARITHMETIC_LOG10_STUB;
 import static com.oracle.graal.hotspot.amd64.AMD64HotSpotForeignCallsProvider.ARITHMETIC_LOG_STUB;
 import static com.oracle.graal.hotspot.amd64.AMD64HotSpotForeignCallsProvider.ARITHMETIC_SIN_STUB;
+import static com.oracle.graal.hotspot.amd64.AMD64HotSpotForeignCallsProvider.ARITHMETIC_POW_STUB;
 import static com.oracle.graal.hotspot.amd64.AMD64HotSpotForeignCallsProvider.ARITHMETIC_TAN_STUB;
 
 import com.oracle.graal.compiler.common.spi.ForeignCallDescriptor;
@@ -101,9 +102,7 @@ public class AMD64HotSpotLoweringProvider extends DefaultHotSpotLoweringProvider
         if (GraalArithmeticStubs.getValue()) {
             switch (operation) {
                 case POW:
-                    // Temporarily disable pow stub
-                    // return ARITHMETIC_POW_STUB;
-                    return operation.foreignCallDescriptor;
+                    return ARITHMETIC_POW_STUB;
             }
         } else if (operation == BinaryOperation.POW) {
             return operation.foreignCallDescriptor;

--- a/graal/com.oracle.graal.lir.amd64/src/com/oracle/graal/lir/amd64/AMD64MathIntrinsicBinaryOp.java
+++ b/graal/com.oracle.graal.lir.amd64/src/com/oracle/graal/lir/amd64/AMD64MathIntrinsicBinaryOp.java
@@ -1813,6 +1813,7 @@ public final class AMD64MathIntrinsicBinaryOp extends AMD64LIRInstruction {
         masm.cmpl(gpr3, 16560);
         masm.jcc(ConditionFlag.Less, bb3);
 
+        masm.leaq(gpr7, externalAddress(lTblPowPtr));
         masm.leaq(gpr8, externalAddress(coeffHPtr));
         masm.movdqu(temp4, new AMD64Address(gpr8, 0));         // 0x00000000,
                                                                // 0xbfd61a00,
@@ -1826,7 +1827,7 @@ public final class AMD64MathIntrinsicBinaryOp extends AMD64LIRInstruction {
         masm.cvtsi2sdl(temp7, gpr1);
         masm.mulpd(temp5, dest);
         masm.mulsd(temp3, dest);
-        masm.subsd(temp5, temp2);
+        masm.subsd(temp5, temp9);
         masm.pshufd(temp1, temp4, 0xE);
         masm.pshufd(temp2, temp3, 0x44);
         masm.unpcklpd(temp5, temp3);


### PR DESCRIPTION
This corrects a corner case posed in the Math.pow unittest.