### PR TITLE
source position in inlined nodes is now set correctly

### DIFF
--- a/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/inlining/InliningUtil.java
+++ b/graal/com.oracle.graal.phases.common/src/com/oracle/graal/phases/common/inlining/InliningUtil.java
@@ -473,7 +473,8 @@ public class InliningUtil {
                 NodeSourcePosition pos = entry.getKey().getNodeSourcePosition();
                 if (pos != null) {
                     NodeSourcePosition callerPos = pos.addCaller(constantReceiver, invokePos);
-                    entry.getValue().setNodeSourcePosition(posMap.putIfAbsent(callerPos, callerPos));
+                    posMap.putIfAbsent(callerPos, callerPos);
+                    entry.getValue().setNodeSourcePosition(posMap.get(callerPos));
                 }
             }
         }


### PR DESCRIPTION
putIfAbsent returns null for new entry and thus results in empty source position