### PR TITLE
Prepare for lowering to expose some constants early

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/meta/DefaultHotSpotLoweringProvider.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/meta/DefaultHotSpotLoweringProvider.java
@@ -257,16 +257,28 @@ public class DefaultHotSpotLoweringProvider extends DefaultJavaLoweringProvider 
                 newObjectSnippets.lower((NewInstanceNode) n, registers, tool);
             }
         } else if (n instanceof DynamicNewInstanceNode) {
+            DynamicNewInstanceNode newInstanceNode = (DynamicNewInstanceNode) n;
+            if (newInstanceNode.getClassClass() == null) {
+                JavaConstant classClassMirror = constantReflection.forObject(Class.class);
+                ConstantNode classClass = ConstantNode.forConstant(classClassMirror, tool.getMetaAccess(), graph);
+                newInstanceNode.setClassClass(classClass);
+            }
             if (graph.getGuardsStage().areFrameStatesAtDeopts()) {
-                newObjectSnippets.lower((DynamicNewInstanceNode) n, registers, tool);
+                newObjectSnippets.lower(newInstanceNode, registers, tool);
             }
         } else if (n instanceof NewArrayNode) {
             if (graph.getGuardsStage().areFrameStatesAtDeopts()) {
                 newObjectSnippets.lower((NewArrayNode) n, registers, tool);
             }
         } else if (n instanceof DynamicNewArrayNode) {
+            DynamicNewArrayNode dynamicNewArrayNode = (DynamicNewArrayNode) n;
+            if (dynamicNewArrayNode.getVoidClass() == null) {
+                JavaConstant voidClassMirror = constantReflection.forObject(void.class);
+                ConstantNode voidClass = ConstantNode.forConstant(voidClassMirror, tool.getMetaAccess(), graph);
+                dynamicNewArrayNode.setVoidClass(voidClass);
+            }
             if (graph.getGuardsStage().areFrameStatesAtDeopts()) {
-                newObjectSnippets.lower((DynamicNewArrayNode) n, registers, tool);
+                newObjectSnippets.lower(dynamicNewArrayNode, registers, tool);
             }
         } else if (n instanceof VerifyHeapNode) {
             if (graph.getGuardsStage().areFrameStatesAtDeopts()) {

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/nodes/type/KlassPointerStamp.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/nodes/type/KlassPointerStamp.java
@@ -56,6 +56,10 @@ public final class KlassPointerStamp extends MetaspacePointerStamp {
         return KLASS_NON_NULL;
     }
 
+    public static KlassPointerStamp klassAlwaysNull() {
+        return KLASS_ALWAYS_NULL;
+    }
+
     private KlassPointerStamp(boolean nonNull, boolean alwaysNull) {
         this(nonNull, alwaysNull, null);
     }

--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/replacements/arraycopy/ArrayCopySnippets.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/replacements/arraycopy/ArrayCopySnippets.java
@@ -78,6 +78,7 @@ import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.hotspot.HotSpotResolvedObjectType;
 import jdk.vm.ci.meta.DeoptimizationAction;
 import jdk.vm.ci.meta.DeoptimizationReason;
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -196,8 +197,8 @@ public class ArrayCopySnippets implements Snippets {
      * underlying type is really an array type.
      */
     @Snippet
-    public static void arraycopySlowPathIntrinsic(Object src, int srcPos, Object dest, int destPos, int length, @ConstantParameter JavaKind elementKind, @ConstantParameter SnippetInfo slowPath,
-                    @ConstantParameter Object slowPathArgument) {
+    public static void arraycopySlowPathIntrinsic(Object src, int srcPos, Object dest, int destPos, int length, KlassPointer predictedKlass, @ConstantParameter JavaKind elementKind,
+                    @ConstantParameter SnippetInfo slowPath, @ConstantParameter Object slowPathArgument) {
         Object nonNullSrc = GraalDirectives.guardingNonNull(src);
         Object nonNullDest = GraalDirectives.guardingNonNull(dest);
         KlassPointer srcHub = loadHub(nonNullSrc);
@@ -211,7 +212,7 @@ public class ArrayCopySnippets implements Snippets {
             nonZeroLengthDynamicCounter.inc();
             nonZeroLengthDynamicCopiedCounter.add(length);
         }
-        ArrayCopySlowPathNode.arraycopy(nonNullSrc, srcPos, nonNullDest, destPos, length, elementKind, slowPath, slowPathArgument);
+        ArrayCopySlowPathNode.arraycopy(nonNullSrc, srcPos, nonNullDest, destPos, length, predictedKlass, elementKind, slowPath, slowPathArgument);
     }
 
     /**
@@ -522,6 +523,14 @@ public class ArrayCopySnippets implements Snippets {
                 args.addConst("unrolledLength", arraycopy.getLength().asJavaConstant().asInt());
                 args.addConst("elementKind", componentKind != null ? componentKind : JavaKind.Illegal);
             } else if (snippetInfo == arraycopySlowPathIntrinsicSnippet) {
+                ValueNode predictedKlass = null;
+                if (slowPathArgument == arraycopyPredictedObjectWorkSnippet) {
+                    HotSpotResolvedObjectType arrayClass = (HotSpotResolvedObjectType) tool.getMetaAccess().lookupJavaType(Object[].class);
+                    predictedKlass = ConstantNode.forConstant(KlassPointerStamp.klassNonNull(), arrayClass.klass(), tool.getMetaAccess(), arraycopy.graph());
+                } else {
+                    predictedKlass = ConstantNode.forConstant(KlassPointerStamp.klassAlwaysNull(), JavaConstant.NULL_POINTER, tool.getMetaAccess(), arraycopy.graph());
+                }
+                args.add("predictedKlass", predictedKlass);
                 args.addConst("elementKind", componentKind != null ? componentKind : JavaKind.Illegal);
                 args.addConst("slowPath", slowPathSnippetInfo);
                 assert slowPathArgument != null;
@@ -554,9 +563,7 @@ public class ArrayCopySnippets implements Snippets {
                 args.add("length", arraycopy.getLength());
             }
             if (snippetInfo == arraycopyPredictedObjectWorkSnippet) {
-                HotSpotResolvedObjectType arrayKlass = (HotSpotResolvedObjectType) tool.getMetaAccess().lookupJavaType(Object[].class);
-                ValueNode objectArrayKlass = ConstantNode.forConstant(KlassPointerStamp.klassNonNull(), arrayKlass.klass(), tool.getMetaAccess(), arraycopy.graph());
-                args.add("objectArrayKlass", objectArrayKlass);
+                args.add("objectArrayKlass", arraycopy.getPredictedKlass());
                 args.addConst("counter", arraycopyCallCounters.get(JavaKind.Object));
                 args.addConst("copiedCounter", arraycopyCallCopiedCounters.get(JavaKind.Object));
             }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/DynamicNewArrayNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/DynamicNewArrayNode.java
@@ -49,6 +49,13 @@ public class DynamicNewArrayNode extends AbstractNewArrayNode implements Canonic
     @Input ValueNode elementType;
 
     /**
+     * Class pointer to void.class needs to be exposed earlier than this node is lowered so that it
+     * can be replaced by the AOT machinery. If it's not needed for lowering this input can be
+     * ignored.
+     */
+    @OptionalInput ValueNode voidClass;
+
+    /**
      * A non-null value indicating the worst case element type. Mainly useful for distinguishing
      * Object arrays from primitive arrays.
      */
@@ -102,8 +109,8 @@ public class DynamicNewArrayNode extends AbstractNewArrayNode implements Canonic
         return new NewArrayNode(type, length(), fillContents(), stateBefore());
     }
 
-    public static boolean throwsIllegalArgumentException(Class<?> elementType) {
-        return elementType == void.class;
+    public static boolean throwsIllegalArgumentException(Class<?> elementType, Class<?> voidClass) {
+        return elementType == voidClass;
     }
 
     public static boolean throwsIllegalArgumentException(ResolvedJavaType elementType) {
@@ -121,4 +128,12 @@ public class DynamicNewArrayNode extends AbstractNewArrayNode implements Canonic
         return newArray(componentType, length, false, knownElementKind);
     }
 
+    public ValueNode getVoidClass() {
+        return voidClass;
+    }
+
+    public void setVoidClass(ValueNode newVoidClass) {
+        updateUsages(voidClass, newVoidClass);
+        voidClass = newVoidClass;
+    }
 }

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/DynamicNewInstanceNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/DynamicNewInstanceNode.java
@@ -42,6 +42,13 @@ public class DynamicNewInstanceNode extends AbstractNewObjectNode implements Can
 
     @Input ValueNode clazz;
 
+    /**
+     * Class pointer to class.class needs to be exposed earlier than this node is lowered so that it
+     * can be replaced by the AOT machinery. If it's not needed for lowering this input can be
+     * ignored.
+     */
+    @OptionalInput ValueNode classClass;
+
     public DynamicNewInstanceNode(ValueNode clazz, boolean fillContents) {
         this(TYPE, clazz, fillContents, null);
     }
@@ -71,11 +78,20 @@ public class DynamicNewInstanceNode extends AbstractNewObjectNode implements Can
         return new NewInstanceNode(type, fillContents(), stateBefore());
     }
 
-    public static boolean throwsInstantiationException(Class<?> type) {
-        return type.isPrimitive() || type.isArray() || type.isInterface() || Modifier.isAbstract(type.getModifiers()) || type == Class.class;
+    public static boolean throwsInstantiationException(Class<?> type, Class<?> classClass) {
+        return type.isPrimitive() || type.isArray() || type.isInterface() || Modifier.isAbstract(type.getModifiers()) || type == classClass;
     }
 
     public static boolean throwsInstantiationException(ResolvedJavaType type, MetaAccessProvider metaAccess) {
         return type.isPrimitive() || type.isArray() || type.isInterface() || Modifier.isAbstract(type.getModifiers()) || type.equals(metaAccess.lookupJavaType(Class.class));
+    }
+
+    public ValueNode getClassClass() {
+        return classClass;
+    }
+
+    public void setClassClass(ValueNode newClassClass) {
+        updateUsages(classClass, newClassClass);
+        classClass = newClassClass;
     }
 }


### PR DESCRIPTION
This is a small part of the AOT changes just to test the process with GitHub out. The proposed change introduces a new API point `prepareForLowering()` in `Lowerable` in order to allow nodes to prepare to the lowering process. In AOT this is used to expose some of the constants for nodes that would otherwise be lowered after the frame states are fixed, which is too late for the constant replacement phase (will be introduced later) to work with. 