### PR TITLE
Add missing barriers for allocations and final fields

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/replacements/NewObjectSnippets.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/replacements/NewObjectSnippets.java
@@ -94,6 +94,7 @@ import com.oracle.graal.nodes.debug.DynamicCounterNode;
 import com.oracle.graal.nodes.debug.VerifyHeapNode;
 import com.oracle.graal.nodes.extended.BranchProbabilityNode;
 import com.oracle.graal.nodes.extended.ForeignCallNode;
+import com.oracle.graal.nodes.extended.MembarNode;
 import com.oracle.graal.nodes.java.DynamicNewArrayNode;
 import com.oracle.graal.nodes.java.DynamicNewInstanceNode;
 import com.oracle.graal.nodes.java.NewArrayNode;
@@ -113,6 +114,7 @@ import com.oracle.graal.replacements.nodes.ExplodeLoopNode;
 import com.oracle.graal.word.Word;
 
 import jdk.vm.ci.code.CodeUtil;
+import jdk.vm.ci.code.MemoryBarriers;
 import jdk.vm.ci.code.Register;
 import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntimeProvider;
@@ -447,6 +449,7 @@ public class NewObjectSnippets implements Snippets {
         } else if (REPLACEMENTS_ASSERTIONS_ENABLED) {
             fillWithGarbage(size, memory, constantSize, instanceHeaderSize(INJECTED_VMCONFIG), false, useSnippetCounters);
         }
+        MembarNode.memoryBarrier(MemoryBarriers.STORE_STORE, INIT_LOCATION);
         return memory.toObject();
     }
 
@@ -478,6 +481,7 @@ public class NewObjectSnippets implements Snippets {
         } else if (REPLACEMENTS_ASSERTIONS_ENABLED) {
             fillWithGarbage(allocationSize, memory, false, headerSize, maybeUnroll, useSnippetCounters);
         }
+        MembarNode.memoryBarrier(MemoryBarriers.STORE_STORE, INIT_LOCATION);
         return memory.toObject();
     }
 

--- a/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/FinalFieldBarrierNode.java
+++ b/graal/com.oracle.graal.nodes/src/com/oracle/graal/nodes/java/FinalFieldBarrierNode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.nodes.java;
+
+import static com.oracle.graal.nodeinfo.NodeCycles.CYCLES_20;
+import static com.oracle.graal.nodeinfo.NodeSize.SIZE_2;
+import static jdk.vm.ci.code.MemoryBarriers.LOAD_STORE;
+import static jdk.vm.ci.code.MemoryBarriers.STORE_STORE;
+
+import com.oracle.graal.compiler.common.type.StampFactory;
+import com.oracle.graal.graph.NodeClass;
+import com.oracle.graal.nodeinfo.NodeInfo;
+import com.oracle.graal.nodes.FixedWithNextNode;
+import com.oracle.graal.nodes.ValueNode;
+import com.oracle.graal.nodes.extended.MembarNode;
+import com.oracle.graal.nodes.spi.Lowerable;
+import com.oracle.graal.nodes.spi.LoweringTool;
+import com.oracle.graal.nodes.spi.Virtualizable;
+import com.oracle.graal.nodes.spi.VirtualizerTool;
+import com.oracle.graal.nodes.virtual.VirtualObjectNode;
+
+@NodeInfo(cycles = CYCLES_20, size = SIZE_2)
+public class FinalFieldBarrierNode extends FixedWithNextNode implements Virtualizable, Lowerable {
+    public static final NodeClass<FinalFieldBarrierNode> TYPE = NodeClass.create(FinalFieldBarrierNode.class);
+
+    @Input private ValueNode value;
+
+    public FinalFieldBarrierNode(ValueNode value) {
+        super(TYPE, StampFactory.forVoid());
+        this.value = value;
+    }
+
+    public ValueNode getValue() {
+        return value;
+    }
+
+    @Override
+    public void virtualize(VirtualizerTool tool) {
+        if (tool.getAlias(value) instanceof VirtualObjectNode) {
+            tool.delete();
+        }
+    }
+
+    @Override
+    public void lower(LoweringTool tool) {
+        graph().replaceFixedWithFixed(this, graph().add(new MembarNode(LOAD_STORE | STORE_STORE)));
+    }
+}

--- a/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/DefaultJavaLoweringProvider.java
+++ b/graal/com.oracle.graal.replacements/src/com/oracle/graal/replacements/DefaultJavaLoweringProvider.java
@@ -88,6 +88,7 @@ import com.oracle.graal.nodes.java.AccessIndexedNode;
 import com.oracle.graal.nodes.java.ArrayLengthNode;
 import com.oracle.graal.nodes.java.AtomicReadAndWriteNode;
 import com.oracle.graal.nodes.java.CompareAndSwapNode;
+import com.oracle.graal.nodes.java.FinalFieldBarrierNode;
 import com.oracle.graal.nodes.java.InstanceOfDynamicNode;
 import com.oracle.graal.nodes.java.InstanceOfNode;
 import com.oracle.graal.nodes.java.LoadFieldNode;
@@ -124,6 +125,7 @@ import com.oracle.graal.replacements.nodes.UnaryMathIntrinsicNode;
 import com.oracle.graal.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation;
 
 import jdk.vm.ci.code.CodeUtil;
+import jdk.vm.ci.code.MemoryBarriers;
 import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.meta.DeoptimizationAction;
 import jdk.vm.ci.meta.DeoptimizationReason;
@@ -729,7 +731,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
         return new NewArrayNode(((VirtualArrayNode) virtual).componentType(), length, true);
     }
 
-    public static void finishAllocatedObjects(LoweringTool tool, CommitAllocationNode commit, ValueNode[] allocations) {
+    public void finishAllocatedObjects(LoweringTool tool, CommitAllocationNode commit, ValueNode[] allocations) {
         StructuredGraph graph = commit.graph();
         for (int objIndex = 0; objIndex < commit.getVirtualObjects().size(); objIndex++) {
             FixedValueAnchorNode anchor = graph.add(new FixedValueAnchorNode(allocations[objIndex]));
@@ -748,6 +750,25 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
             int index = commit.getVirtualObjects().indexOf(addObject.getVirtualObject());
             addObject.replaceAtUsagesAndDelete(allocations[index]);
         }
+        insertAllocationBarrier(commit, graph);
+    }
+
+    /**
+     * Insert the required {@link MemoryBarriers#STORE_STORE} barrier for an allocation and also
+     * include the {@link MemoryBarriers#LOAD_STORE} required for final fields if any final fields
+     * are being written, as if {@link FinalFieldBarrierNode} were emitted.
+     */
+    private void insertAllocationBarrier(CommitAllocationNode commit, StructuredGraph graph) {
+        int barrier = MemoryBarriers.STORE_STORE;
+        outer: for (VirtualObjectNode vobj : commit.getVirtualObjects()) {
+            for (ResolvedJavaField field : vobj.type().getInstanceFields(true)) {
+                if (field.isFinal()) {
+                    barrier = barrier | MemoryBarriers.LOAD_STORE;
+                    break outer;
+                }
+            }
+        }
+        graph.addAfterFixed(commit, graph.add(new MembarNode(barrier, initLocationIdentity())));
     }
 
     /**


### PR DESCRIPTION
This adds the required barriers for final fields and allocations.  The final field barriers can be EA'd and the lowered later into the proper barriers when the allocation is finally committed.