### PR TITLE
Allow JVMCI from local and jprt builds of the JDK

### DIFF
--- a/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/JVMCIVersionCheck.java
+++ b/graal/com.oracle.graal.hotspot/src/com/oracle/graal/hotspot/JVMCIVersionCheck.java
@@ -99,6 +99,10 @@ class JVMCIVersionCheck {
                 // The snapshot of http://hg.openjdk.java.net/jdk9/hs tip is expected to work
                 return;
             }
+            if (vmVersion.contains("internal")) {
+                // Allow local builds
+                return;
+            }
             // http://openjdk.java.net/jeps/223
             // Only support EA builds until GA is available
             if (vmVersion.startsWith("9-ea+")) {


### PR DESCRIPTION
That's small change allows to run Graal on top of locally and internally built JDK